### PR TITLE
fix: course id should be converted to course key for edx-platform functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+1.1.0 - 2023-08-09
+******************
+* fix for course id to course key conversion
+
 1.0.0 - 2023-08-08
 ******************
 

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/admin.py
+++ b/learning_assistant/admin.py
@@ -1,0 +1,15 @@
+"""
+Django Admin pages.
+"""
+from django.contrib import admin
+
+from learning_assistant.models import CoursePrompt
+
+
+@admin.register(CoursePrompt)
+class CoursePromptAdmin(admin.ModelAdmin):
+    """
+    Admin panel for course prompts.
+    """
+
+    list_display = ('id', 'course_id')

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -4,6 +4,7 @@ V1 API Views.
 import logging
 
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from opaque_keys.edx.keys import CourseKey
 from rest_framework import status as http_status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import IsAuthenticated
@@ -45,15 +46,16 @@ class CourseChatView(APIView):
             ]
         }
         """
-        if not learning_assistant_is_active(course_id):
+        course_key = CourseKey.from_string(course_id)
+        if not learning_assistant_is_active(course_key):
             return Response(
                 status=http_status.HTTP_403_FORBIDDEN,
                 data={'detail': 'Learning assistant not enabled for course.'}
             )
 
         # If user does not have a verified enrollment, or is not staff, they should not have access
-        user_role = get_user_role(request.user, course_id)
-        enrollment_object = CourseEnrollment.get_enrollment(request.user, course_id)
+        user_role = get_user_role(request.user, course_key)
+        enrollment_object = CourseEnrollment.get_enrollment(request.user, course_key)
         enrollment_mode = enrollment_object.mode if enrollment_object else None
         if (
             (enrollment_mode not in CourseMode.VERIFIED_MODES)


### PR DESCRIPTION
## [MST-2045](https://2u-internal.atlassian.net/browse/MST-2045)

The edx-platform functions imported require a course key to be passed in, not a course id. Passing in the course ID was causing a 500 error when making calls to the endpoint. I tested locally and the endpoint is able to make all the required checks prior to forwarding the request to the chat completion endpoint. 

As part of testing, I also needed to set up a course prompt, so I included the ability to add a course prompt via django admin to this PR.