### PR TITLE
feat: give audit learners access to la bot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+1.3.3 - 2023-09-07
+******************
+* Allow any enrolled learner to access API.
+
 1.3.2 - 2023-08-25
 ******************
 * Remove deserialization of prompt field, as it is represented in the python

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -53,12 +53,12 @@ class CourseChatView(APIView):
                 data={'detail': 'Learning assistant not enabled for course.'}
             )
 
-        # If user does not have a verified enrollment, or is not staff, they should not have access
+        # If user does not have an enrollment record, or is not staff, they should not have access
         user_role = get_user_role(request.user, course_key)
         enrollment_object = CourseEnrollment.get_enrollment(request.user, course_key)
         enrollment_mode = enrollment_object.mode if enrollment_object else None
         if (
-            (enrollment_mode not in CourseMode.VERIFIED_MODES)
+            (enrollment_mode not in CourseMode.ALL_MODES)
             and user_role not in ('staff', 'instructor')
         ):
             return Response(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -91,9 +91,13 @@ class CourseChatViewTests(LoggedInTestCase):
 
     @patch('learning_assistant.views.learning_assistant_is_active')
     @patch('learning_assistant.views.get_user_role')
-    def test_user_not_verified_not_staff(self, mock_role, mock_waffle):
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
+    def test_user_no_enrollment_not_staff(self, mock_mode, mock_enrollment, mock_role, mock_waffle):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
+        mock_mode.ALL_MODES = ['verified']
+        mock_enrollment.return_value = None
 
         response = self.client.post(reverse('chat', kwargs={'course_id': self.course_id}))
         self.assertEqual(response.status_code, 403)
@@ -133,9 +137,13 @@ class CourseChatViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.get_chat_response')
     @patch('learning_assistant.views.learning_assistant_is_active')
     @patch('learning_assistant.views.get_user_role')
-    def test_chat_response(self, mock_role, mock_waffle, mock_chat_response):
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
+    def test_chat_response(self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response):
         mock_waffle.return_value = True
-        mock_role.return_value = 'staff'
+        mock_role.return_value = 'student'
+        mock_mode.ALL_MODES = ['verified']
+        mock_enrollment.return_value = MagicMock(mode='verified')
         mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})
 
         CoursePrompt.objects.create(


### PR DESCRIPTION
## [MST-2130](https://2u-internal.atlassian.net/browse/MST-2130)

This PR grants learners with an audit enrollment access to the learning assistant backend.