### PR TITLE
feat: use reduced message to avoid maxing out tokens

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+1.4.0 - 2023-09-11
+******************
+* Send reduced message list if needed to avoid going over token limit
+
 1.3.3 - 2023-09-07
 ******************
 * Allow any enrolled learner to access API.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '1.3.3'
+__version__ = '1.4.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -94,6 +94,6 @@ class CourseChatView(APIView):
                 'course_id': course_id
             }
         )
-        status_code, message = get_chat_response(message_setup + message_list)
+        status_code, message = get_chat_response(message_setup, message_list)
 
         return Response(status=status_code, data=message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 """
 Tests for the utils functions
 """
+import copy
 import json
 from unittest.mock import MagicMock, patch
 
@@ -10,7 +11,7 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from requests.exceptions import ConnectTimeout
 
-from learning_assistant.utils import get_chat_response
+from learning_assistant.utils import get_chat_response, get_reduced_message_list
 
 
 @ddt.ddt
@@ -20,6 +21,10 @@ class GetChatResponseTests(TestCase):
     """
     def setUp(self):
         super().setUp()
+        self.system_message = [
+            {'role': 'system', 'content': 'Do this'},
+            {'role': 'system', 'content': 'Do that'},
+        ]
         self.message_list = [
             {'role': 'assistant', 'content': 'Hello'},
             {'role': 'user', 'content': 'Goodbye'},
@@ -27,13 +32,13 @@ class GetChatResponseTests(TestCase):
 
     @override_settings(CHAT_COMPLETION_API=None)
     def test_no_endpoint_setting(self):
-        status_code, message = get_chat_response(self.message_list)
+        status_code, message = get_chat_response(self.system_message, self.message_list)
         self.assertEqual(status_code, 404)
         self.assertEqual(message, 'Completion endpoint is not defined.')
 
     @override_settings(CHAT_COMPLETION_API_KEY=None)
     def test_no_endpoint_key_setting(self):
-        status_code, message = get_chat_response(self.message_list)
+        status_code, message = get_chat_response(self.system_message, self.message_list)
         self.assertEqual(status_code, 404)
         self.assertEqual(message, 'Completion endpoint is not defined.')
 
@@ -47,7 +52,7 @@ class GetChatResponseTests(TestCase):
             body=json.dumps(message_response),
         )
 
-        status_code, message = get_chat_response(self.message_list)
+        status_code, message = get_chat_response(self.system_message, self.message_list)
         self.assertEqual(status_code, 200)
         self.assertEqual(message, message_response)
 
@@ -61,7 +66,7 @@ class GetChatResponseTests(TestCase):
             body=json.dumps(message_response),
         )
 
-        status_code, message = get_chat_response(self.message_list)
+        status_code, message = get_chat_response(self.system_message, self.message_list)
         self.assertEqual(status_code, 500)
         self.assertEqual(message, message_response)
 
@@ -72,7 +77,7 @@ class GetChatResponseTests(TestCase):
     @patch('learning_assistant.utils.requests')
     def test_timeout(self, exception, mock_requests):
         mock_requests.post = MagicMock(side_effect=exception())
-        status_code, _ = get_chat_response(self.message_list)
+        status_code, _ = get_chat_response(self.system_message, self.message_list)
         self.assertEqual(status_code, 502)
 
     @patch('learning_assistant.utils.requests')
@@ -83,12 +88,44 @@ class GetChatResponseTests(TestCase):
         connect_timeout = settings.CHAT_COMPLETION_API_CONNECT_TIMEOUT
         read_timeout = settings.CHAT_COMPLETION_API_READ_TIMEOUT
         headers = {'Content-Type': 'application/json', 'x-api-key': settings.CHAT_COMPLETION_API_KEY}
-        body = json.dumps({'message_list': self.message_list})
+        body = json.dumps({'message_list': self.system_message + self.message_list})
 
-        get_chat_response(self.message_list)
+        get_chat_response(self.system_message, self.message_list)
         mock_requests.post.assert_called_with(
             completion_endpoint,
             headers=headers,
             data=body,
             timeout=(connect_timeout, read_timeout)
         )
+
+
+class GetReducedMessageListTests(TestCase):
+    """
+    Tests for the _reduced_message_list helper function
+    """
+    def setUp(self):
+        super().setUp()
+        self.system_message = [
+            {'role': 'system', 'content': 'Do this'},
+            {'role': 'system', 'content': 'Do that'},
+        ]
+        self.message_list = [
+            {'role': 'assistant', 'content': 'Hello'},
+            {'role': 'user', 'content': 'Goodbye'},
+        ]
+
+    @override_settings(CHAT_COMPLETION_MAX_TOKENS=30)
+    @override_settings(CHAT_COMPLETION_RESPONSE_TOKENS=1)
+    def test_message_list_reduced(self):
+        """
+        If the number of tokens in the message list is greater than allowed, assert that messages are removed
+        """
+        # pass in copy of list, as it is modified as part of the reduction
+        reduced_message_list = get_reduced_message_list(self.system_message, copy.deepcopy(self.message_list))
+        self.assertEqual(len(reduced_message_list), 1)
+        self.assertEqual(reduced_message_list, self.message_list[-1:])
+
+    def test_message_list(self):
+        reduced_message_list = get_reduced_message_list(self.system_message, copy.deepcopy(self.message_list))
+        self.assertEqual(len(reduced_message_list), 2)
+        self.assertEqual(reduced_message_list, self.message_list)


### PR DESCRIPTION
## [MST-2134](https://2u-internal.atlassian.net/browse/MST-2134)

To avoid going over the maximum amount of tokens allowed, we should reduce the user message list and send only the most recent messages that do not go over the number of allotted tokens. 