### PR TITLE
feat: cache unit content

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+Unreleased
+**********
+* Add content cache
+
 1.5.0 - 2023-10-18
 ******************
 * Add management command to generate course prompts

--- a/learning_assistant/text_utils.py
+++ b/learning_assistant/text_utils.py
@@ -34,7 +34,7 @@ class _HTMLToTextHelper(HTMLParser):  # lint-amnesty, pylint: disable=abstract-m
 
     def handle_starttag(self, tag, _):
         """On each tag, check whether this is a tag we think is content."""
-        tags_to_filter = getattr(settings, 'HTML_TAGS_TO_REMOVE', None)
+        tags_to_filter = getattr(settings, 'LEARNING_ASSISTANT_HTML_TAGS_TO_REMOVE', None)
         self._is_content = not (tags_to_filter and tag in tags_to_filter)
 
     def handle_data(self, data):

--- a/test_settings.py
+++ b/test_settings.py
@@ -69,3 +69,9 @@ DISCOVERY_BASE_URL = 'http://edx.devstack.discovery:18381'
 DISCOVERY_BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = 'http://edx.devstack.lms:18000/oauth2'
 DISCOVERY_BACKEND_SERVICE_EDX_OAUTH2_KEY = 'discovery-backend-service-key'
 DISCOVERY_BACKEND_SERVICE_EDX_OAUTH2_SECRET = 'discovery-backend-service-secret'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}


### PR DESCRIPTION
## [COSMO-72](https://2u-internal.atlassian.net/browse/COSMO-72)

In order to avoid multiple calls into modulestore for course content, the content should be cached on a per user, course, and unit usage key basis. The default TTL is set to 360 seconds, which was determined to be an appropriate amount of time after analyzing the duration of conversations typically had with the learning assistant.