### PR TITLE
feat: add course waffle flag for content integration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+Unreleased
+**********
+
+2.0.1 - 2021-01-08
+******************
+* Gate content integration with waffle flag
+
 2.0.0 - 2024-01-03
 ******************
 * Add content cache

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.cache import cache
 from edx_django_utils.cache import get_cache_key
 from jinja2 import BaseLoader, Environment
+from opaque_keys.edx.keys import CourseKey
 
 from learning_assistant.constants import ACCEPTED_CATEGORY_TYPES, CATEGORY_TYPE_MAP
 from learning_assistant.models import CoursePrompt
@@ -18,6 +19,7 @@ from learning_assistant.platform_imports import (
     traverse_block_pre_order,
 )
 from learning_assistant.text_utils import html_to_text
+from learning_assistant.toggles import course_content_enabled
 
 log = logging.getLogger(__name__)
 
@@ -124,7 +126,9 @@ def render_prompt_template(request, user_id, course_id, unit_usage_key):
     Return a rendered prompt template, specified by the LEARNING_ASSISTANT_PROMPT_TEMPLATE setting.
     """
     unit_content = ''
-    if unit_usage_key:
+
+    course_run_key = CourseKey.from_string(course_id)
+    if unit_usage_key and course_content_enabled(course_run_key):
         _, unit_content = get_block_content(request, user_id, course_id, unit_usage_key)
 
     template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')

--- a/learning_assistant/toggles.py
+++ b/learning_assistant/toggles.py
@@ -1,0 +1,34 @@
+"""
+Toggles for learning-assistant app.
+"""
+
+WAFFLE_NAMESPACE = 'learning_assistant'
+
+# .. toggle_name: learning_assistant.enable_course_content
+# .. toggle_implementation: CourseWaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Waffle flag to enable the course content integration with the learning assistant
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2024-01-08
+# .. toggle_target_removal_date: 2024-01-31
+# .. toggle_tickets: COSMO-80
+ENABLE_COURSE_CONTENT = 'enable_course_content'
+
+
+def _is_learning_assistant_waffle_flag_enabled(flag_name, course_key):
+    """
+    Import and return Waffle flag for enabling the summary hook.
+    """
+    # pylint: disable=import-outside-toplevel
+    try:
+        from openedx.core.djangoapps.waffle_utils import CourseWaffleFlag
+        return CourseWaffleFlag(f'{WAFFLE_NAMESPACE}.{flag_name}', __name__).is_enabled(course_key)
+    except ImportError:
+        return False
+
+
+def course_content_enabled(course_key):
+    """
+    Return whether the learning_assistant.enable_course_content WaffleFlag is on.
+    """
+    return _is_learning_assistant_waffle_flag_enabled(ENABLE_COURSE_CONTENT, course_key)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -207,12 +207,17 @@ class GetBlockContentAPITests(TestCase):
         self.assertEqual(items, content_items)
 
     @ddt.data(
-        'This is content.',
-        ''
+        ('This is content.', True),
+        ('', True),
+        ('This is content.', False),
+        ('', False),
     )
+    @ddt.unpack
+    @patch('learning_assistant.toggles._is_learning_assistant_waffle_flag_enabled')
     @patch('learning_assistant.api.get_block_content')
-    def test_render_prompt_template(self, unit_content, mock_get_content):
+    def test_render_prompt_template(self, unit_content, flag_enabled, mock_get_content, mock_is_flag_enabled):
         mock_get_content.return_value = (len(unit_content), unit_content)
+        mock_is_flag_enabled.return_value = flag_enabled
 
         # mock arguments that are passed through to `get_block_content` function. the value of these
         # args does not matter for this test right now, as the `get_block_content` function is entirely mocked.
@@ -223,7 +228,7 @@ class GetBlockContentAPITests(TestCase):
 
         prompt_text = render_prompt_template(request, user_id, course_id, unit_usage_key)
 
-        if unit_content:
+        if unit_content and flag_enabled:
             self.assertIn(unit_content, prompt_text)
         else:
             self.assertNotIn('The following text is useful.', prompt_text)


### PR DESCRIPTION
## [COSMO-80](https://2u-internal.atlassian.net/browse/COSMO-80)

This pull request adds a course waffle flag that will control whether or not course content is added to the prompt template. 

Because the toggle is defined outside of a function, an import error occurs at runtime if the CourseWaffleFlag class is not mocked out properly.