### PR TITLE
feat: return 403 if Learning Assistant feature toggle or instructor toggle disabled

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,5 +8,8 @@ coverage:
       default:
         enabled: yes
         target: 100%
+ignore:
+ - "learning_assistant/platform_imports.py"
+
 
 comment: false

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '3.0.0'
+__version__ = '3.1.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/platform_imports.py
+++ b/learning_assistant/platform_imports.py
@@ -57,3 +57,23 @@ def get_cache_course_run_data(course_run_id, fields):
     # pylint: disable=import-error, import-outside-toplevel
     from openedx.core.djangoapps.catalog.utils import get_course_run_data
     return get_course_run_data(course_run_id, fields)
+
+
+def learning_assistant_available(course_key):
+    """
+    Return whether the Learning Assistant is available in the course represented by the course_key.
+
+    Note that this may be different than whether the Learning Assistant is enabled in the course. The value returned by
+    this fuction represents whether the Learning Assistant is available in the course and, perhaps, whether it is
+    enabled. Course teams can disable the Learning Assistant via the LearningAssistantCourseEnabled model, so, in those
+    cases, the Learning Assistant may be available and disabled.
+
+    Arguments:
+        * course_key (CourseKey): the course's key
+
+    Returns:
+        * bool: whether the Learning Assistant feature is available
+    """
+    # pylint: disable=import-error, import-outside-toplevel
+    from lms.djangoapps.courseware.toggles import learning_assistant_is_active
+    return learning_assistant_is_active(course_key)

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -15,12 +15,10 @@ try:
     from common.djangoapps.course_modes.models import CourseMode
     from common.djangoapps.student.models import CourseEnrollment
     from lms.djangoapps.courseware.access import get_user_role
-    from lms.djangoapps.courseware.toggles import learning_assistant_is_active
 except ImportError:
-    # If the waffle flag is false, the endpoint will force an early return.
-    learning_assistant_is_active = False
+    pass
 
-from learning_assistant.api import render_prompt_template
+from learning_assistant.api import learning_assistant_enabled, render_prompt_template
 from learning_assistant.serializers import MessageSerializer
 from learning_assistant.utils import get_chat_response
 
@@ -47,7 +45,8 @@ class CourseChatView(APIView):
         }
         """
         courserun_key = CourseKey.from_string(course_id)
-        if not learning_assistant_is_active(courserun_key):
+
+        if not learning_assistant_enabled(courserun_key):
             return Response(
                 status=http_status.HTTP_403_FORBIDDEN,
                 data={'detail': 'Learning assistant not enabled for course.'}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -81,13 +81,13 @@ class CourseChatViewTests(LoggedInTestCase):
         super().setUp()
         self.course_id = 'course-v1:edx+test+23'
 
-    @patch('learning_assistant.views.learning_assistant_is_active')
+    @patch('learning_assistant.views.learning_assistant_enabled')
     def test_course_waffle_inactive(self, mock_waffle):
         mock_waffle.return_value = False
         response = self.client.post(reverse('chat', kwargs={'course_id': self.course_id}))
         self.assertEqual(response.status_code, 403)
 
-    @patch('learning_assistant.views.learning_assistant_is_active')
+    @patch('learning_assistant.views.learning_assistant_enabled')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
@@ -101,7 +101,7 @@ class CourseChatViewTests(LoggedInTestCase):
         self.assertEqual(response.status_code, 403)
 
     @patch('learning_assistant.views.render_prompt_template')
-    @patch('learning_assistant.views.learning_assistant_is_active')
+    @patch('learning_assistant.views.learning_assistant_enabled')
     @patch('learning_assistant.views.get_user_role')
     def test_invalid_messages(self, mock_role, mock_waffle, mock_render):
         mock_waffle.return_value = True
@@ -124,7 +124,7 @@ class CourseChatViewTests(LoggedInTestCase):
 
     @patch('learning_assistant.views.render_prompt_template')
     @patch('learning_assistant.views.get_chat_response')
-    @patch('learning_assistant.views.learning_assistant_is_active')
+    @patch('learning_assistant.views.learning_assistant_enabled')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')


### PR DESCRIPTION
### Description

**Jira**: [COSMO-161](https://2u-internal.atlassian.net/browse/COSMO-161)

This commit modifies the Learning Assistant access logic.

Previously, the chat view would return a 403 response code if the `learning_assistant_available` function returned False (i.e. the `COURSEWARE_LEARNING_ASSISTANT` `CourseWaffleFlag` was disabled).

Now, the chat view will return a 403 response code if either the `learning_assistant_available` function returns False or if there is a False override in the `LearningAssistantCourseEnabled` model corresponding to the course in which the chat is being requested.