### PR TITLE
feat: replace waffle flag with setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+3.6.0 - 2024-02-13
+******************
+* Enable backend access by course waffle flag or django setting.
+
 3.4.0 - 2024-01-30
 ******************
 * Add new GET endpoint to retrieve whether Learning Assistant is enabled in a given course.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '3.5.0'
+__version__ = '3.6.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -17,7 +17,7 @@ from learning_assistant.platform_imports import (
     block_leaf_filter,
     get_single_block,
     get_text_transcript,
-    learning_assistant_available,
+    learning_assistant_available_flag,
     traverse_block_pre_order,
 )
 from learning_assistant.text_utils import html_to_text
@@ -116,6 +116,13 @@ def render_prompt_template(request, user_id, course_id, unit_usage_key):
     template = Environment(loader=BaseLoader).from_string(template_string)
     data = template.render(unit_content=unit_content)
     return data
+
+
+def learning_assistant_available(course_key):
+    """
+    Return whether or not the learning assistant is available via django setting or course waffle flag.
+    """
+    return getattr(settings, 'LEARNING_ASSISTANT_AVAILABLE', False) or learning_assistant_available_flag(course_key)
 
 
 def learning_assistant_enabled(course_key):

--- a/learning_assistant/platform_imports.py
+++ b/learning_assistant/platform_imports.py
@@ -59,7 +59,7 @@ def get_cache_course_run_data(course_run_id, fields):
     return get_course_run_data(course_run_id, fields)
 
 
-def learning_assistant_available(course_key):
+def learning_assistant_available_flag(course_key):
     """
     Return whether the Learning Assistant is available in the course represented by the course_key.
 

--- a/learning_assistant/plugins_api.py
+++ b/learning_assistant/plugins_api.py
@@ -7,8 +7,12 @@ Instead, the CourseApp abstract methods are implemented here and
 imported into and used by the LearningAssistantCourseApp. This way, these implementations can be tested.
 """
 
-from learning_assistant.api import learning_assistant_enabled, set_learning_assistant_enabled
-from learning_assistant.platform_imports import get_user_role, learning_assistant_available
+from learning_assistant.api import (
+    learning_assistant_available,
+    learning_assistant_enabled,
+    set_learning_assistant_enabled,
+)
+from learning_assistant.platform_imports import get_user_role
 from learning_assistant.utils import user_role_is_staff
 
 
@@ -17,7 +21,8 @@ def is_available(course_key):
     Return a boolean indicating this course app's availability for a given course.
 
     If an app is not available, it will not show up in the UI at all for that course,
-    and it will not be possible to enable/disable/configure it.
+    and it will not be possible to enable/disable/configure it, unless the platform wide setting
+    LEARNING_ASSISTANT_AVAILABLE is set to True.
 
     Args:
         course_key (CourseKey): Course key for course whose availability is being checked.

--- a/test_settings.py
+++ b/test_settings.py
@@ -84,3 +84,5 @@ LEARNING_ASSISTANT_PROMPT_TEMPLATE = (
     "\""
     "{% endif %}"
 )
+
+LEARNING_ASSISTANT_AVAILABLE = True


### PR DESCRIPTION
## [COSMO-191](https://2u-internal.atlassian.net/browse/COSMO-191)

To prepare for a wider release, the use of a course waffle flag to enable the learning assistant should be replaced by a platform wide django setting. 

If no setting is defined, the feature will default to a disabled state.