### PR TITLE
feat: update request to xpert backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.2.0 - 2024-02-28
+******************
+* Modify call to Xpert backend to prevent use of course index.
+
 4.1.0 - 2024-02-26
 ******************
 * Use course cache to inject course title and course skill names into prompt template.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.1.0'
+__version__ = '4.2.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -27,15 +27,7 @@ def get_reduced_message_list(prompt_template, message_list):
     """
     If messages are larger than allotted token amount, return a smaller list of messages.
     """
-    # the total number of system tokens is a sum of estimated tokens that includes the prompt template, the
-    # course title, and the course skills. It is necessary to include estimations for the course title and
-    # course skills, as the chat endpoint the prompt is being passed to is responsible for filling in the values
-    # for both of those variables.
-    total_system_tokens = (
-        _estimated_message_tokens(prompt_template)
-        + _estimated_message_tokens('.' * 40)  # average number of characters per course name is 40
-        + _estimated_message_tokens('.' * 116)  # average number of characters for skill names is 116
-    )
+    total_system_tokens = _estimated_message_tokens(prompt_template)
 
     max_tokens = getattr(settings, 'CHAT_COMPLETION_MAX_TOKENS', 16385)
     response_tokens = getattr(settings, 'CHAT_COMPLETION_RESPONSE_TOKENS', 1000)
@@ -55,28 +47,23 @@ def get_reduced_message_list(prompt_template, message_list):
         # insert message at beginning of list, because we are traversing the message list from most recent to oldest
         new_message_list.insert(0, new_message)
 
-    return new_message_list
+    system_message = {'role': 'system', 'content': prompt_template}
+
+    return [system_message] + new_message_list
 
 
-def create_request_body(prompt_template, message_list, course_id):
+def create_request_body(prompt_template, message_list):
     """
     Form request body to be passed to the chat endpoint.
     """
     response_body = {
-        'context': {
-            'content': prompt_template,
-            'render': {
-                'doc_id': course_id,
-                'fields': ['skillNames', 'title']
-            }
-        },
         'message_list': get_reduced_message_list(prompt_template, message_list)
     }
 
     return response_body
 
 
-def get_chat_response(prompt_template, message_list, course_id):
+def get_chat_response(prompt_template, message_list):
     """
     Pass message list to chat endpoint, as defined by the CHAT_COMPLETION_API setting.
     """
@@ -87,7 +74,7 @@ def get_chat_response(prompt_template, message_list, course_id):
         connect_timeout = getattr(settings, 'CHAT_COMPLETION_API_CONNECT_TIMEOUT', 1)
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
-        body = create_request_body(prompt_template, message_list, course_id)
+        body = create_request_body(prompt_template, message_list)
 
         try:
             response = requests.post(

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -97,7 +97,7 @@ class CourseChatView(APIView):
 
         prompt_template = render_prompt_template(request, request.user.id, course_run_id, unit_id, course_id)
 
-        status_code, message = get_chat_response(prompt_template, message_list, course_id)
+        status_code, message = get_chat_response(prompt_template, message_list)
 
         return Response(status=status_code, data=message)
 


### PR DESCRIPTION
## [COSMO-202](https://2u-internal.atlassian.net/browse/COSMO-202)

If the `context` field is included in the post request to the Xpert Platform backend, the course index will be used. Because the course index does not include all courses in which Xpert LA should be available, we should opt out of using the course index (for now). 