### PR TITLE
feat: support variation param for model and prompt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.3.0 - 2024-07-01
+******************
+* Adds optinal parameter to use updated prompt and model for the chat response.
+
 4.2.0 - 2024-02-28
 ******************
 * Modify call to Xpert backend to prevent use of course index.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Unreleased
 
 4.3.0 - 2024-07-01
 ******************
-* Adds optinal parameter to use updated prompt and model for the chat response.
+* Adds optional parameter to use updated prompt and model for the chat response.
 
 4.2.0 - 2024-02-28
 ******************

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.2.0'
+__version__ = '4.3.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -105,7 +105,7 @@ def get_block_content(request, user_id, course_id, unit_usage_key):
 
 def render_prompt_template(request, user_id, course_run_id, unit_usage_key, course_id, template_string):
     """
-    Return a rendered prompt template, specified by the LEARNING_ASSISTANT_PROMPT_TEMPLATE setting.
+    Return a rendered prompt template.
     """
     unit_content = ''
 

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -103,7 +103,7 @@ def get_block_content(request, user_id, course_id, unit_usage_key):
     return cache_data['content_length'], cache_data['content_items']
 
 
-def render_prompt_template(request, user_id, course_run_id, unit_usage_key, course_id):
+def render_prompt_template(request, user_id, course_run_id, unit_usage_key, course_id, template_string):
     """
     Return a rendered prompt template, specified by the LEARNING_ASSISTANT_PROMPT_TEMPLATE setting.
     """
@@ -117,7 +117,6 @@ def render_prompt_template(request, user_id, course_run_id, unit_usage_key, cour
     skill_names = course_data['skill_names']
     title = course_data['title']
 
-    template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
     template = Environment(loader=BaseLoader).from_string(template_string)
     data = template.render(unit_content=unit_content, skill_names=skill_names, title=title)
     return data

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -18,6 +18,7 @@ CATEGORY_TYPE_MAP = {
 
 class GptModels:
     GPT_3_5_TURBO = 'gpt-3.5-turbo'
+    GPT_3_5_TURBO_0125 = 'gpt-3.5-turbo-0125'
     GPT_4o = 'gpt-4o'
 
 

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -14,3 +14,12 @@ CATEGORY_TYPE_MAP = {
     "html": "TEXT",
     "video": "VIDEO",
 }
+
+
+class GptModels:
+    GPT_3_5_TURBO = 'gpt-3.5-turbo'
+    GPT_4o = 'gpt-4o'
+
+
+class ResponseVariations:
+    GPT4_UPDATED_PROMPT = 'updated_prompt'

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -52,18 +52,19 @@ def get_reduced_message_list(prompt_template, message_list):
     return [system_message] + new_message_list
 
 
-def create_request_body(prompt_template, message_list):
+def create_request_body(prompt_template, message_list, gpt_model):
     """
     Form request body to be passed to the chat endpoint.
     """
     response_body = {
-        'message_list': get_reduced_message_list(prompt_template, message_list)
+        'message_list': get_reduced_message_list(prompt_template, message_list),
+        'model': gpt_model,
     }
 
     return response_body
 
 
-def get_chat_response(prompt_template, message_list):
+def get_chat_response(prompt_template, message_list, gpt_model):
     """
     Pass message list to chat endpoint, as defined by the CHAT_COMPLETION_API setting.
     """
@@ -74,7 +75,7 @@ def get_chat_response(prompt_template, message_list):
         connect_timeout = getattr(settings, 'CHAT_COMPLETION_API_CONNECT_TIMEOUT', 1)
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
-        body = create_request_body(prompt_template, message_list)
+        body = create_request_body(prompt_template, message_list, gpt_model)
 
         try:
             response = requests.post(

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -102,7 +102,7 @@ class CourseChatView(APIView):
             gpt_model = GptModels.GPT_4o
             template_string = getattr(settings, 'LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE', '')
         else:
-            gpt_model = GptModels.GPT_3_5_TURBO
+            gpt_model = GptModels.GPT_3_5_TURBO_0125
             template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
 
         prompt_template = render_prompt_template(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ import itertools
 from unittest.mock import MagicMock, patch
 
 import ddt
+from django.conf import settings
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from opaque_keys.edx.keys import CourseKey, UsageKey
@@ -202,8 +203,11 @@ class GetBlockContentAPITests(TestCase):
         course_run_id = self.course_run_id
         unit_usage_key = 'block-v1:edX+A+B+type@vertical+block@verticalD'
         course_id = 'edx+test'
+        template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
 
-        prompt_text = render_prompt_template(request, user_id, course_run_id, unit_usage_key, course_id)
+        prompt_text = render_prompt_template(
+            request, user_id, course_run_id, unit_usage_key, course_id, template_string
+        )
 
         if unit_content and flag_enabled:
             self.assertIn(unit_content, prompt_text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ class GetChatResponseTests(TestCase):
         self.course_id = 'edx+test'
 
     def get_response(self):
-        return get_chat_response(self.prompt_template, self.message_list)
+        return get_chat_response(self.prompt_template, self.message_list, 'gpt-version-test')
 
     @override_settings(CHAT_COMPLETION_API=None)
     def test_no_endpoint_setting(self):
@@ -89,7 +89,8 @@ class GetChatResponseTests(TestCase):
         headers = {'Content-Type': 'application/json', 'x-api-key': settings.CHAT_COMPLETION_API_KEY}
 
         response_body = {
-            'message_list': [{'role': 'system', 'content': self.prompt_template}] + self.message_list
+            'message_list': [{'role': 'system', 'content': self.prompt_template}] + self.message_list,
+            'model': 'gpt-version-test',
         }
 
         self.get_response()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,6 +14,8 @@ from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 
+from learning_assistant.constants import GptModels, ResponseVariations
+
 User = get_user_model()
 
 
@@ -155,13 +157,15 @@ class CourseChatViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
-    def test_chat_response(self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render):
+    def test_chat_response_default(
+        self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
+    ):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
         mock_enrollment.return_value = MagicMock(mode='verified')
         mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})
-        mock_render.return_value = 'This is a template'
+        mock_render.return_value = 'This is the default template'
         test_unit_id = 'test-unit-id'
 
         test_data = [
@@ -178,6 +182,54 @@ class CourseChatViewTests(LoggedInTestCase):
 
         render_args = mock_render.call_args.args
         self.assertIn(test_unit_id, render_args)
+
+        mock_chat_response.assert_called_with(
+            'This is the default template',
+            test_data,
+            GptModels.GPT_3_5_TURBO
+        )
+
+    @patch('learning_assistant.views.render_prompt_template')
+    @patch('learning_assistant.views.get_chat_response')
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    @patch('learning_assistant.views.get_user_role')
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
+    def test_chat_response_variation(
+        self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
+    ):
+        mock_waffle.return_value = True
+        mock_role.return_value = 'student'
+        mock_mode.VERIFIED_MODES = ['verified']
+        mock_enrollment.return_value = MagicMock(mode='verified')
+        mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})
+        mock_render.return_value = 'This is a template for GPT-4o variation'
+        test_unit_id = 'test-unit-id'
+        test_response_variation = ResponseVariations.GPT4_UPDATED_PROMPT
+
+        test_data = [
+            {'role': 'user', 'content': 'What is 2+2?'},
+            {'role': 'assistant', 'content': 'It is 4'}
+        ]
+
+        response = self.client.post(
+            reverse(
+                'chat',
+                kwargs={'course_run_id': self.course_id}
+            )+f'?unit_id={test_unit_id}&response_variation={test_response_variation}',
+            data=json.dumps(test_data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        render_args = mock_render.call_args.args
+        self.assertIn(test_unit_id, render_args)
+
+        mock_chat_response.assert_called_with(
+            'This is a template for GPT-4o variation',
+            test_data,
+            GptModels.GPT_4o
+        )
 
 
 @ddt.ddt

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -189,7 +189,7 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_chat_response.assert_called_with(
             'Rendered template mock',
             test_data,
-            GptModels.GPT_3_5_TURBO
+            GptModels.GPT_3_5_TURBO_0125
         )
 
     @ddt.data(ResponseVariations.GPT4_UPDATED_PROMPT, 'invalid-variation')
@@ -232,7 +232,7 @@ class CourseChatViewTests(LoggedInTestCase):
             expected_model = GptModels.GPT_4o
         else:
             expected_template = 'This is the default template'
-            expected_model = GptModels.GPT_3_5_TURBO
+            expected_model = GptModels.GPT_3_5_TURBO_0125
 
         render_args = mock_render.call_args.args
         self.assertIn(test_unit_id, render_args)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,7 +10,7 @@ import ddt
 from django.conf import settings
 from django.contrib.auth import get_user_model, login
 from django.http import HttpRequest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
 
@@ -71,6 +71,7 @@ class LoggedInTestCase(TestCase):
         self.client.login_user(self.user)
 
 
+@ddt.ddt
 class CourseChatViewTests(LoggedInTestCase):
     """
     Test for the CourseChatView
@@ -157,6 +158,7 @@ class CourseChatViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
+    @override_settings(LEARNING_ASSISTANT_PROMPT_TEMPLATE='This is the default template')
     def test_chat_response_default(
         self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
     ):
@@ -165,7 +167,7 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_mode.VERIFIED_MODES = ['verified']
         mock_enrollment.return_value = MagicMock(mode='verified')
         mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})
-        mock_render.return_value = 'This is the default template'
+        mock_render.return_value = 'Rendered template mock'
         test_unit_id = 'test-unit-id'
 
         test_data = [
@@ -182,30 +184,33 @@ class CourseChatViewTests(LoggedInTestCase):
 
         render_args = mock_render.call_args.args
         self.assertIn(test_unit_id, render_args)
+        self.assertIn('This is the default template', render_args)
 
         mock_chat_response.assert_called_with(
-            'This is the default template',
+            'Rendered template mock',
             test_data,
             GptModels.GPT_3_5_TURBO
         )
 
+    @ddt.data(ResponseVariations.GPT4_UPDATED_PROMPT, 'invalid-variation')
     @patch('learning_assistant.views.render_prompt_template')
     @patch('learning_assistant.views.get_chat_response')
     @patch('learning_assistant.views.learning_assistant_enabled')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
+    @override_settings(LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE='This is a template for GPT-4o variation')
+    @override_settings(LEARNING_ASSISTANT_PROMPT_TEMPLATE='This is the default template')
     def test_chat_response_variation(
-        self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
+        self, variation, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
     ):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
         mock_enrollment.return_value = MagicMock(mode='verified')
         mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})
-        mock_render.return_value = 'This is a template for GPT-4o variation'
+        mock_render.return_value = 'Rendered template mock'
         test_unit_id = 'test-unit-id'
-        test_response_variation = ResponseVariations.GPT4_UPDATED_PROMPT
 
         test_data = [
             {'role': 'user', 'content': 'What is 2+2?'},
@@ -216,19 +221,27 @@ class CourseChatViewTests(LoggedInTestCase):
             reverse(
                 'chat',
                 kwargs={'course_run_id': self.course_id}
-            )+f'?unit_id={test_unit_id}&response_variation={test_response_variation}',
+            )+f'?unit_id={test_unit_id}&response_variation={variation}',
             data=json.dumps(test_data),
             content_type='application/json',
         )
         self.assertEqual(response.status_code, 200)
 
+        if variation == ResponseVariations.GPT4_UPDATED_PROMPT:
+            expected_template = 'This is a template for GPT-4o variation'
+            expected_model = GptModels.GPT_4o
+        else:
+            expected_template = 'This is the default template'
+            expected_model = GptModels.GPT_3_5_TURBO
+
         render_args = mock_render.call_args.args
         self.assertIn(test_unit_id, render_args)
+        self.assertIn(expected_template, render_args)
 
         mock_chat_response.assert_called_with(
-            'This is a template for GPT-4o variation',
+            'Rendered template mock',
             test_data,
-            GptModels.GPT_4o
+            expected_model,
         )
 
 


### PR DESCRIPTION
Adds an optional `response_variation` parameter when posting to the course chat endpoint to use a different model and/or prompt.

### JIRA [COSMO-256](https://2u-internal.atlassian.net/browse/COSMO-356)