### PR TITLE
feat: remove GPT model field in post request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.3.1 - 2024-09-10
+******************
+* Remove GPT model field as part of POST request to Xpert backend
+
 4.3.0 - 2024-07-01
 ******************
 * Adds optional parameter to use updated prompt and model for the chat response.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.3.0'
+__version__ = '4.3.1'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -14,13 +14,3 @@ CATEGORY_TYPE_MAP = {
     "html": "TEXT",
     "video": "VIDEO",
 }
-
-
-class GptModels:
-    GPT_3_5_TURBO = 'gpt-3.5-turbo'
-    GPT_3_5_TURBO_0125 = 'gpt-3.5-turbo-0125'
-    GPT_4o = 'gpt-4o'
-
-
-class ResponseVariations:
-    GPT4_UPDATED_PROMPT = 'updated_prompt'

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -52,19 +52,18 @@ def get_reduced_message_list(prompt_template, message_list):
     return [system_message] + new_message_list
 
 
-def create_request_body(prompt_template, message_list, gpt_model):
+def create_request_body(prompt_template, message_list):
     """
     Form request body to be passed to the chat endpoint.
     """
     response_body = {
         'message_list': get_reduced_message_list(prompt_template, message_list),
-        'model': gpt_model,
     }
 
     return response_body
 
 
-def get_chat_response(prompt_template, message_list, gpt_model):
+def get_chat_response(prompt_template, message_list):
     """
     Pass message list to chat endpoint, as defined by the CHAT_COMPLETION_API setting.
     """
@@ -75,7 +74,7 @@ def get_chat_response(prompt_template, message_list, gpt_model):
         connect_timeout = getattr(settings, 'CHAT_COMPLETION_API_CONNECT_TIMEOUT', 1)
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
-        body = create_request_body(prompt_template, message_list, gpt_model)
+        body = create_request_body(prompt_template, message_list)
 
         try:
             response = requests.post(

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -21,7 +21,6 @@ except ImportError:
     pass
 
 from learning_assistant.api import get_course_id, learning_assistant_enabled, render_prompt_template
-from learning_assistant.constants import GptModels, ResponseVariations
 from learning_assistant.serializers import MessageSerializer
 from learning_assistant.utils import get_chat_response, user_role_is_staff
 
@@ -75,7 +74,6 @@ class CourseChatView(APIView):
             )
 
         unit_id = request.query_params.get('unit_id')
-        response_variation = request.query_params.get('response_variation')
 
         message_list = request.data
         serializer = MessageSerializer(data=message_list, many=True)
@@ -98,17 +96,12 @@ class CourseChatView(APIView):
 
         course_id = get_course_id(course_run_id)
 
-        if response_variation == ResponseVariations.GPT4_UPDATED_PROMPT:
-            gpt_model = GptModels.GPT_4o
-            template_string = getattr(settings, 'LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE', '')
-        else:
-            gpt_model = GptModels.GPT_3_5_TURBO_0125
-            template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
+        template_string = getattr(settings, 'LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE', '')
 
         prompt_template = render_prompt_template(
             request, request.user.id, course_run_id, unit_id, course_id, template_string
         )
-        status_code, message = get_chat_response(prompt_template, message_list, gpt_model)
+        status_code, message = get_chat_response(prompt_template, message_list)
 
         return Response(status=status_code, data=message)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,7 @@ class GetChatResponseTests(TestCase):
         self.course_id = 'edx+test'
 
     def get_response(self):
-        return get_chat_response(self.prompt_template, self.message_list, 'gpt-version-test')
+        return get_chat_response(self.prompt_template, self.message_list)
 
     @override_settings(CHAT_COMPLETION_API=None)
     def test_no_endpoint_setting(self):
@@ -90,7 +90,6 @@ class GetChatResponseTests(TestCase):
 
         response_body = {
             'message_list': [{'role': 'system', 'content': self.prompt_template}] + self.message_list,
-            'model': 'gpt-version-test',
         }
 
         self.get_response()


### PR DESCRIPTION
## [COSMO-475](https://2u-internal.atlassian.net/browse/COSMO-475)

The Xpert platform team deprecated GPT 3.5, and any requests specifying that model are resulting in a 4xx response. All users should now be using the default model, which is GPT 4.0-mini.