### PR TITLE
fix: handle invalid unit ids

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.3.2 - 2024-09-19
+******************
+* Add error handling for invalid unit usage keys
+
 4.3.1 - 2024-09-10
 ******************
 * Remove GPT model field as part of POST request to Xpert backend

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.3.1'
+__version__ = '4.3.2'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -112,7 +112,7 @@ def render_prompt_template(request, user_id, course_run_id, unit_usage_key, cour
         try:
             _, unit_content = get_block_content(request, user_id, course_run_id, unit_usage_key)
         except InvalidKeyError:
-            log.info(
+            log.warning(
                 'Failed to retrieve course content for course_id=%(course_run_id)s because of '
                 'invalid unit_id=%(unit_usage_key)s',
                 {'course_run_id': course_run_id, 'unit_usage_key': unit_usage_key}


### PR DESCRIPTION
## [COSMO-432](https://2u-internal.atlassian.net/browse/COSMO-432)

Occasionally requests coming from the frontend contain a `null` unit ID. This causes an error, as the null value is interpreted as a string, and then used as a unit ID although it is invalid. Via local testing, I also found that `last` was a unit ID value that could be passed along in the POST request to our Xpert backend. 

To avoid unhandled 500 responses, we should catch the `InvalidKeyError` being thrown, and log when it is happening. The request should still complete successfully, even without a valid unit ID, as content is not necessary for making a successful request. 