### PR TITLE
feat: use default prompt template

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.3.3 - 2024-10-15
+******************
+* Use `LEARNING_ASSISTANT_PROMPT_TEMPLATE` for prompt
+
 4.3.2 - 2024-09-19
 ******************
 * Add error handling for invalid unit usage keys

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.3.2'
+__version__ = '4.3.3'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -96,7 +96,7 @@ class CourseChatView(APIView):
 
         course_id = get_course_id(course_run_id)
 
-        template_string = getattr(settings, 'LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE', '')
+        template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
 
         prompt_template = render_prompt_template(
             request, request.user.id, course_run_id, unit_id, course_id, template_string

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -156,7 +156,7 @@ class CourseChatViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
-    @override_settings(LEARNING_ASSISTANT_EXPERIMENTAL_PROMPT_TEMPLATE='This is the default template')
+    @override_settings(LEARNING_ASSISTANT_PROMPT_TEMPLATE='This is the default template')
     def test_chat_response_default(
         self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_chat_response, mock_render
     ):


### PR DESCRIPTION
## [COSMO-475](https://2u-internal.atlassian.net/browse/COSMO-475)

As part of the experiment clean up, the experimental prompt has been adopted as the "default" prompt. The backend should be updated to now use the default/non-experimental setting.