### PR TITLE
feat: GET endpoint to retrieve message history

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Unreleased
 **********
 * Add LearningAssistantMessage model
 
+4.4.0 - 2024-10-30
+******************
+* Add new GET endpoint to retrieve a user's message history in a given course.
+
 4.3.3 - 2024-10-15
 ******************
 * Use `LEARNING_ASSISTANT_PROMPT_TEMPLATE` for prompt

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.3.3'
+__version__ = '4.4.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -189,11 +189,12 @@ def get_course_id(course_run_id):
     return course_key
 
 
-def get_message_history(course_id, user):
+def get_message_history(course_id, user, message_limit):
     """
     Given ARG, return RET
     """
-    # NOTE: How much should we limit the message history to?
+    # NOTE: message_limit = how many messages back we go
     # note for self: this is descending order for the created date, which shows the latest first.
-    message_history = LearningAssistantMessage.objects.filter(course_id=course_id, user=user).order_by('-created')[:50]
+    message_history = LearningAssistantMessage.objects.filter(
+        course_id=course_id, user=user).order_by('-created')[:message_limit]
     return message_history.content

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -195,13 +195,6 @@ def get_message_history(course_id, user, message_count):
 
     Returns a number of messages equal to the message_count value.
     """
-    # If the received message count exceeds the number of messages present, we return all the messages queried.
-    actual_message_count = LearningAssistantMessage.objects.count()
-    if message_count > actual_message_count:
-        amount_to_get = actual_message_count
-    else:
-        amount_to_get = message_count
-
     message_history = LearningAssistantMessage.objects.filter(
-        course_id=course_id, user=user).order_by('-created')[:amount_to_get]
+        course_id=course_id, user=user).order_by('-created')[:message_count]
     return message_history

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -189,12 +189,12 @@ def get_course_id(course_run_id):
     return course_key
 
 
-def get_message_history(course_id, user, message_limit):
+def get_message_history(course_id, user, message_count):
     """
     Given ARG, return RET
     """
-    # NOTE: message_limit = how many messages back we go
+    # NOTE: message_count = how many messages back we go
     # note for self: this is descending order for the created date, which shows the latest first.
     message_history = LearningAssistantMessage.objects.filter(
-        course_id=course_id, user=user).order_by('-created')[:message_limit]
+        course_id=course_id, user=user).order_by('-created')[:message_count]
     return message_history.content

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -195,7 +195,6 @@ def get_message_history(course_id, user, message_count):
 
     Returns a number of messages equal to the message_count value.
     """
-
     # If the received message count exceeds the number of messages present, we return all the messages queried.
     actual_message_count = LearningAssistantMessage.objects.count()
     if message_count > actual_message_count:

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -195,6 +195,14 @@ def get_message_history(course_id, user, message_count):
 
     Returns a number of messages equal to the message_count value.
     """
+
+    # If the received message count exceeds the number of messages present, we return all the messages queried.
+    actual_message_count = LearningAssistantMessage.objects.count()
+    if message_count > actual_message_count:
+        amount_to_get = actual_message_count
+    else:
+        amount_to_get = message_count
+
     message_history = LearningAssistantMessage.objects.filter(
-        course_id=course_id, user=user).order_by('-created')[:message_count]
-    return message_history.content
+        course_id=course_id, user=user).order_by('-created')[:amount_to_get]
+    return message_history

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -11,7 +11,7 @@ from opaque_keys import InvalidKeyError
 
 from learning_assistant.constants import ACCEPTED_CATEGORY_TYPES, CATEGORY_TYPE_MAP
 from learning_assistant.data import LearningAssistantCourseEnabledData
-from learning_assistant.models import LearningAssistantCourseEnabled
+from learning_assistant.models import LearningAssistantCourseEnabled, LearningAssistantMessage
 from learning_assistant.platform_imports import (
     block_get_children,
     block_leaf_filter,
@@ -187,3 +187,13 @@ def get_course_id(course_run_id):
     course_data = get_cache_course_run_data(course_run_id, ['course'])
     course_key = course_data['course']
     return course_key
+
+
+def get_message_history(course_id, user):
+    """
+    Given ARG, return RET
+    """
+    # NOTE: How much should we limit the message history to?
+    # note for self: this is descending order for the created date, which shows the latest first.
+    message_history = LearningAssistantMessage.objects.filter(course_id=course_id, user=user).order_by('-created')[:50]
+    return message_history.content

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -191,10 +191,10 @@ def get_course_id(course_run_id):
 
 def get_message_history(course_id, user, message_count):
     """
-    Given ARG, return RET
+    Given a course run id (str), user (User), and message count (int), return the associated message history.
+
+    Returns a number of messages equal to the message_count value.
     """
-    # NOTE: message_count = how many messages back we go
-    # note for self: this is descending order for the created date, which shows the latest first.
     message_history = LearningAssistantMessage.objects.filter(
         course_id=course_id, user=user).order_by('-created')[:message_count]
     return message_history.content

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -15,4 +15,4 @@ CATEGORY_TYPE_MAP = {
     "video": "VIDEO",
 }
 
-MESSAGE_LIMIT = r'^[0-9]+$'
+MESSAGE_COUNT = r'^[0-9]+$'

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -14,3 +14,5 @@ CATEGORY_TYPE_MAP = {
     "html": "TEXT",
     "video": "VIDEO",
 }
+
+MESSAGE_LIMIT = r'^[0-9]+$'

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -14,5 +14,3 @@ CATEGORY_TYPE_MAP = {
     "html": "TEXT",
     "video": "VIDEO",
 }
-
-MESSAGE_COUNT = r'^[0-9]+$'

--- a/learning_assistant/text_utils.py
+++ b/learning_assistant/text_utils.py
@@ -20,7 +20,7 @@ def cleanup_text(text):
     return stripped
 
 
-class _HTMLToTextHelper(HTMLParser):  # lint-amnesty, pylint: disable=abstract-method
+class _HTMLToTextHelper(HTMLParser):  # lint-amnesty
     """
     Helper function for html_to_text below.
     """

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -3,7 +3,7 @@ URLs for learning_assistant.
 """
 from django.urls import re_path
 
-from learning_assistant.constants import COURSE_ID_PATTERN
+from learning_assistant.constants import COURSE_ID_PATTERN, MESSAGE_LIMIT
 from learning_assistant.views import (
     CourseChatView,
     LearningAssistantEnabledView,
@@ -24,8 +24,8 @@ urlpatterns = [
         name='enabled',
     ),
     re_path(
-        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history',
+        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/{MESSAGE_LIMIT}',
         LearningAssistantMessageHistoryView.as_view(),
-        name='enabled',
+        name='message-history',
     ),
 ]

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -3,7 +3,7 @@ URLs for learning_assistant.
 """
 from django.urls import re_path
 
-from learning_assistant.constants import COURSE_ID_PATTERN, MESSAGE_COUNT
+from learning_assistant.constants import COURSE_ID_PATTERN
 from learning_assistant.views import CourseChatView, LearningAssistantEnabledView, LearningAssistantMessageHistoryView
 
 app_name = 'learning_assistant'
@@ -20,7 +20,7 @@ urlpatterns = [
         name='enabled',
     ),
     re_path(
-        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/{MESSAGE_COUNT}',
+        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/<int:message_count>',
         LearningAssistantMessageHistoryView.as_view(),
         name='message-history',
     ),

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name='enabled',
     ),
     re_path(
-        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/<int:message_count>',
+        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history',
         LearningAssistantMessageHistoryView.as_view(),
         name='message-history',
     ),

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -3,7 +3,7 @@ URLs for learning_assistant.
 """
 from django.urls import re_path
 
-from learning_assistant.constants import COURSE_ID_PATTERN, MESSAGE_LIMIT
+from learning_assistant.constants import COURSE_ID_PATTERN, MESSAGE_COUNT
 from learning_assistant.views import (
     CourseChatView,
     LearningAssistantEnabledView,
@@ -24,7 +24,7 @@ urlpatterns = [
         name='enabled',
     ),
     re_path(
-        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/{MESSAGE_LIMIT}',
+        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history/{MESSAGE_COUNT}',
         LearningAssistantMessageHistoryView.as_view(),
         name='message-history',
     ),

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -4,7 +4,11 @@ URLs for learning_assistant.
 from django.urls import re_path
 
 from learning_assistant.constants import COURSE_ID_PATTERN
-from learning_assistant.views import CourseChatView, LearningAssistantEnabledView
+from learning_assistant.views import (
+    CourseChatView,
+    LearningAssistantEnabledView,
+    LearningAssistantMessageHistoryView,
+)
 
 app_name = 'learning_assistant'
 
@@ -17,6 +21,11 @@ urlpatterns = [
     re_path(
         fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/enabled',
         LearningAssistantEnabledView.as_view(),
+        name='enabled',
+    ),
+    re_path(
+        fr'learning_assistant/v1/course_id/{COURSE_ID_PATTERN}/history',
+        LearningAssistantMessageHistoryView.as_view(),
         name='enabled',
     ),
 ]

--- a/learning_assistant/urls.py
+++ b/learning_assistant/urls.py
@@ -4,11 +4,7 @@ URLs for learning_assistant.
 from django.urls import re_path
 
 from learning_assistant.constants import COURSE_ID_PATTERN, MESSAGE_COUNT
-from learning_assistant.views import (
-    CourseChatView,
-    LearningAssistantEnabledView,
-    LearningAssistantMessageHistoryView,
-)
+from learning_assistant.views import CourseChatView, LearningAssistantEnabledView, LearningAssistantMessageHistoryView
 
 app_name = 'learning_assistant'
 

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -205,14 +205,14 @@ class LearningAssistantMessageHistoryView(APIView):
         user_role = get_user_role(request.user, courserun_key)
         enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
         enrollment_mode = enrollment_object.mode if enrollment_object else None
-        # if (
-        #     (enrollment_mode not in CourseMode.VERIFIED_MODES)
-        #     and not user_role_is_staff(user_role)
-        # ):
-        #     return Response(
-        #         status=http_status.HTTP_403_FORBIDDEN,
-        #         data={'detail': 'Must be staff or have valid enrollment.'}
-        #     )
+        if (
+            (enrollment_mode not in CourseMode.VERIFIED_MODES)
+            and not user_role_is_staff(user_role)
+        ):
+            return Response(
+                status=http_status.HTTP_403_FORBIDDEN,
+                data={'detail': 'Must be staff or have valid enrollment.'}
+            )
 
         course_id = get_course_id(course_run_id)
         user = request.user

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -20,7 +20,12 @@ try:
 except ImportError:
     pass
 
-from learning_assistant.api import get_course_id, learning_assistant_enabled, render_prompt_template
+from learning_assistant.api import (
+    get_course_id,
+    get_message_history,
+    learning_assistant_enabled,
+    render_prompt_template,
+)
 from learning_assistant.serializers import MessageSerializer
 from learning_assistant.utils import get_chat_response, user_role_is_staff
 
@@ -148,4 +153,70 @@ class LearningAssistantEnabledView(APIView):
             'enabled': learning_assistant_enabled(courserun_key),
         }
 
+        return Response(status=http_status.HTTP_200_OK, data=data)
+
+
+class LearningAssistantMessageHistoryView(APIView):
+    """
+    View to retrieve the message history for user in a course.
+
+    This endpoint returns the message history stored in the LearningAssistantMessage table in a course
+    represented by the course_key, which is provided in the URL.
+
+    Accepts: [GET]
+
+    Path: /learning_assistant/v1/course_id/{course_key}/history
+
+    Parameters:
+        * course_key: the ID of the course
+
+    Responses:
+        * 200: OK
+        * 400: Malformed Request - Course ID is not a valid course ID.
+    """
+
+    authentication_classes = (SessionAuthentication, JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, course_run_id):
+        """
+        Given a course run ID, retrieve the message history for the corresponding user.
+
+        The response will be in the following format.
+
+            {'enabled': <bool>}
+        """
+
+        try:
+            courserun_key = CourseKey.from_string(course_run_id)
+        except InvalidKeyError:
+            return Response(
+                status=http_status.HTTP_400_BAD_REQUEST,
+                data={'detail': 'Course ID is not a valid course ID.'}
+            )
+
+        # TODO: Maybe put this in an api function
+        if not learning_assistant_enabled(courserun_key):
+            return Response(
+                status=http_status.HTTP_403_FORBIDDEN,
+                data={'detail': 'Learning assistant not enabled for course.'}
+            )
+
+        # If user does not have an enrollment record, or is not staff, they should not have access
+        user_role = get_user_role(request.user, courserun_key)
+        enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
+        enrollment_mode = enrollment_object.mode if enrollment_object else None
+        if (
+            (enrollment_mode not in CourseMode.VERIFIED_MODES)
+            and not user_role_is_staff(user_role)
+        ):
+            return Response(
+                status=http_status.HTTP_403_FORBIDDEN,
+                data={'detail': 'Must be staff or have valid enrollment.'}
+            )
+
+        course_id = get_course_id(course_run_id)
+        user = request.user
+        data = get_message_history(course_id, user)
+        
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -193,7 +193,6 @@ class LearningAssistantMessageHistoryView(APIView):
                 },
             }
         """
-
         try:
             courserun_key = CourseKey.from_string(course_run_id)
         except InvalidKeyError:

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -178,7 +178,7 @@ class LearningAssistantMessageHistoryView(APIView):
     authentication_classes = (SessionAuthentication, JwtAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, course_run_id, message_count=50):
+    def get(self, request, course_run_id):
         """
         Given a course run ID, retrieve the message history for the corresponding user.
 
@@ -217,6 +217,7 @@ class LearningAssistantMessageHistoryView(APIView):
         course_id = get_course_id(course_run_id)
         user = request.user
 
+        message_count = int(request.GET.get('message_count', 50))
         message_history = get_message_history(course_id, user, message_count)
         data = MessageSerializer(message_history, many=True).data
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -165,7 +165,7 @@ class LearningAssistantMessageHistoryView(APIView):
 
     Accepts: [GET]
 
-    Path: /learning_assistant/v1/course_id/{course_key}/history/{message_count}
+    Path: /learning_assistant/v1/course_id/{course_key}/history
 
     Parameters:
         * course_key: the ID of the course
@@ -201,7 +201,6 @@ class LearningAssistantMessageHistoryView(APIView):
             )
 
         # If user does not have an enrollment record, or is not staff, they should not have access
-        # NOTE: This will likely be removed once work is done to allow audit learners to access xpert
         user_role = get_user_role(request.user, courserun_key)
         enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
         enrollment_mode = enrollment_object.mode if enrollment_object else None

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -165,7 +165,7 @@ class LearningAssistantMessageHistoryView(APIView):
 
     Accepts: [GET]
 
-    Path: /learning_assistant/v1/course_id/{course_key}/history/{message_limit}
+    Path: /learning_assistant/v1/course_id/{course_key}/history/{message_count}
 
     Parameters:
         * course_key: the ID of the course
@@ -178,7 +178,7 @@ class LearningAssistantMessageHistoryView(APIView):
     authentication_classes = (SessionAuthentication, JwtAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    def get(self, request, course_run_id, message_limit):
+    def get(self, request, course_run_id, message_count):
         """
         Given a course run ID, retrieve the message history for the corresponding user.
 
@@ -224,6 +224,6 @@ class LearningAssistantMessageHistoryView(APIView):
 
         course_id = get_course_id(course_run_id)
         user = request.user
-        data = get_message_history(course_id, user, message_limit)
+        data = get_message_history(course_id, user, message_count)
 
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -347,11 +347,11 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i, _ in enumerate(return_value):
-            self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
-            self.assertEqual(return_value[i].user, expected_value[i].user)
-            self.assertEqual(return_value[i].role, expected_value[i].role)
-            self.assertEqual(return_value[i].content, expected_value[i].content)
+        for i, return_value in enumerate(return_value):
+            self.assertEqual(return_value.course_id, expected_value[i].course_id)
+            self.assertEqual(return_value.user, expected_value[i].user)
+            self.assertEqual(return_value.role, expected_value[i].role)
+            self.assertEqual(return_value.content, expected_value[i].content)
 
     @ddt.data(
         0, 1, 5, 10, 50
@@ -406,11 +406,11 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i, _ in enumerate(return_value):
-            self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
-            self.assertEqual(return_value[i].user, expected_value[i].user)
-            self.assertEqual(return_value[i].role, expected_value[i].role)
-            self.assertEqual(return_value[i].content, expected_value[i].content)
+        for i, return_value in enumerate(return_value):
+            self.assertEqual(return_value.course_id, expected_value[i].course_id)
+            self.assertEqual(return_value.user, expected_value[i].user)
+            self.assertEqual(return_value.role, expected_value[i].role)
+            self.assertEqual(return_value.content, expected_value[i].content)
 
     def test_get_message_course_id_differences(self):
         # Default Message
@@ -443,8 +443,8 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i, _ in enumerate(return_value):
-            self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
-            self.assertEqual(return_value[i].user, expected_value[i].user)
-            self.assertEqual(return_value[i].role, expected_value[i].role)
-            self.assertEqual(return_value[i].content, expected_value[i].content)
+        for i, return_value in enumerate(return_value):
+            self.assertEqual(return_value.course_id, expected_value[i].course_id)
+            self.assertEqual(return_value.user, expected_value[i].user)
+            self.assertEqual(return_value.role, expected_value[i].role)
+            self.assertEqual(return_value.content, expected_value[i].content)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -347,7 +347,7 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i in range(0, len(return_value)):
+        for i, _ in enumerate(return_value):
             self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
             self.assertEqual(return_value[i].user, expected_value[i].user)
             self.assertEqual(return_value[i].role, expected_value[i].role)
@@ -406,7 +406,7 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i in range(0, len(return_value)):
+        for i, _ in enumerate(return_value):
             self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
             self.assertEqual(return_value[i].user, expected_value[i].user)
             self.assertEqual(return_value[i].role, expected_value[i].role)
@@ -443,7 +443,7 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
         # Ensure values are as expected for all LearningAssistantMessage instances
-        for i in range(0, len(return_value)):
+        for i, _ in enumerate(return_value):
             self.assertEqual(return_value[i].course_id, expected_value[i].course_id)
             self.assertEqual(return_value[i].user, expected_value[i].user)
             self.assertEqual(return_value[i].role, expected_value[i].role)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -329,9 +329,6 @@ class GetMessageHistoryTests(TestCase):
         self.role = 'verified'
 
     def test_get_message_history(self):
-        """
-        Test that get_message_history queries all the objects for a course_id and user.
-        """
         message_count = 5
         for i in range(1, message_count + 1):
             LearningAssistantMessage.objects.create(
@@ -360,10 +357,6 @@ class GetMessageHistoryTests(TestCase):
         0, 1, 5, 10, 50
     )
     def test_get_message_history_message_count(self, actual_message_count):
-        """
-        Test that get_message_history returns the expected number of messages based on the message_count
-        parameter and how many LearningAssistantMessage instances actually exist.
-        """
         for i in range(1, actual_message_count + 1):
             LearningAssistantMessage.objects.create(
                 course_id=self.course_id,
@@ -382,9 +375,6 @@ class GetMessageHistoryTests(TestCase):
         self.assertEqual(len(return_value), len(expected_value))
 
     def test_get_message_history_user_difference(self):
-        """
-        Test that get_message_history filters messages by user.
-        """
         # Default Message
         LearningAssistantMessage.objects.create(
             course_id=self.course_id,
@@ -423,9 +413,6 @@ class GetMessageHistoryTests(TestCase):
             self.assertEqual(return_value[i].content, expected_value[i].content)
 
     def test_get_message_course_id_differences(self):
-        """
-        Test that get_message_history filters messages by course_id.
-        """
         # Default Message
         LearningAssistantMessage.objects.create(
             course_id=self.course_id,

--- a/tests/test_plugins_api.py
+++ b/tests/test_plugins_api.py
@@ -19,6 +19,7 @@ class PluginApiTests(TestCase):
     """
     Test suite for the plugins_api module.
     """
+
     def setUp(self):
         super().setUp()
         self.course_key = CourseKey.from_string('course-v1:edx+fake+1')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -14,6 +14,8 @@ from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
 
+from learning_assistant.models import LearningAssistantMessage
+
 User = get_user_model()
 
 
@@ -64,7 +66,7 @@ class LoggedInTestCase(TestCase):
         """
         super().setUp()
         self.client = TestClient()
-        self.user = User(username='tester', email='tester@test.com')
+        self.user = User(username='tester', email='tester@test.com', is_staff=True)
         self.user.save()
         self.client.login_user(self.user)
 
@@ -223,3 +225,29 @@ class LearningAssistantEnabledViewTests(LoggedInTestCase):
         response = self.client.get(reverse('enabled', kwargs={'course_run_id': self.course_id+'+invalid'}))
 
         self.assertEqual(response.status_code, 400)
+
+@ddt.ddt
+class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
+    """
+    Tests for the LearningAssistantMessageHistoryView
+    """
+    def setUp(self):
+        super().setUp()
+        self.course_id = 'course-v1:edx+test+23'
+
+    @patch('learning_assistant.views.get_course_id')
+    def test_get_pls(self, mock_get_course_id):
+        LearningAssistantMessage.objects.create(
+            course_id=self.course_id,
+            user=self.user,
+            role='staff',
+            content='Expected content of message',
+        )
+        message_count = 10
+        mock_get_course_id.return_value = self.course_id
+        response = self.client.get(
+            reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
+            # data=json.dumps(test_data),
+            content_type='application/json'
+        )
+        print(response.data)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -23,6 +23,7 @@ class TestClient(Client):
     """
     Allows for 'fake logins' of a user so we don't need to expose a 'login' HTTP endpoint.
     """
+
     def login_user(self, user):
         """
         Login as specified user.
@@ -212,12 +213,12 @@ class LearningAssistantEnabledViewTests(LoggedInTestCase):
     )
     @ddt.unpack
     @patch('learning_assistant.views.learning_assistant_enabled')
-    def test_learning_assistant_enabled(self, mock_value, expected_value, mock_learning_assistant_enabled):
+    def test_learning_assistant_enabled(self, mock_value, message, mock_learning_assistant_enabled):
         mock_learning_assistant_enabled.return_value = mock_value
         response = self.client.get(reverse('enabled', kwargs={'course_run_id': self.course_id}))
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, {'enabled': expected_value})
+        self.assertEqual(response.data, {'enabled': message})
 
     @patch('learning_assistant.views.learning_assistant_enabled')
     def test_invalid_course_id(self, mock_learning_assistant_enabled):
@@ -226,28 +227,109 @@ class LearningAssistantEnabledViewTests(LoggedInTestCase):
 
         self.assertEqual(response.status_code, 400)
 
+
 @ddt.ddt
 class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
     """
     Tests for the LearningAssistantMessageHistoryView
     """
+
     def setUp(self):
         super().setUp()
         self.course_id = 'course-v1:edx+test+23'
 
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    def test_invalid_course_id(self, mock_learning_assistant_enabled):
+        mock_learning_assistant_enabled.return_value = True
+        response = self.client.get(reverse('enabled', kwargs={'course_run_id': self.course_id+'+invalid'}))
+
+        self.assertEqual(response.status_code, 400)
+
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    def test_course_waffle_inactive(self, mock_waffle):
+        mock_waffle.return_value = False
+        message_count = 5
+        response = self.client.get(
+            reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    def test_learning_assistant_not_enabled(self, mock_learning_assistant_enabled):
+        mock_learning_assistant_enabled.return_value = False
+        message_count = 5
+        response = self.client.get(
+            reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    @patch('learning_assistant.views.get_user_role')
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
+    def test_user_no_enrollment_not_staff(self, mock_mode, mock_enrollment, mock_role, mock_waffle):
+        mock_waffle.return_value = True
+        mock_role.return_value = 'student'
+        mock_mode.VERIFIED_MODES = ['verified']
+        mock_enrollment.return_value = None
+
+        message_count = 5
+        response = self.client.get(
+            reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    @patch('learning_assistant.views.get_user_role')
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
+    def test_user_audit_enrollment_not_staff(self, mock_mode, mock_enrollment, mock_role, mock_waffle):
+        mock_waffle.return_value = True
+        mock_role.return_value = 'student'
+        mock_mode.VERIFIED_MODES = ['verified']
+        mock_enrollment.return_value = MagicMock(mode='audit')
+
+        message_count = 5
+        response = self.client.get(
+            reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, 403)
+
+    @patch('learning_assistant.views.learning_assistant_enabled')
+    @patch('learning_assistant.views.get_user_role')
+    @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
+    @patch('learning_assistant.views.CourseMode')
     @patch('learning_assistant.views.get_course_id')
-    def test_get_pls(self, mock_get_course_id):
+    def test_learning_message_history_view_get(self, mock_get_course_id, mock_mode, mock_enrollment, mock_role, mock_waffle):
+        mock_waffle.return_value = True
+        mock_role.return_value = 'student'
+        mock_mode.VERIFIED_MODES = ['verified']
+        mock_enrollment.return_value = MagicMock(mode='verified')
+
         LearningAssistantMessage.objects.create(
             course_id=self.course_id,
             user=self.user,
             role='staff',
             content='Expected content of message',
         )
-        message_count = 10
+        message_count = 1
         mock_get_course_id.return_value = self.course_id
         response = self.client.get(
             reverse('message-history', kwargs={'course_run_id': self.course_id})+f'?message_count={message_count}',
-            # data=json.dumps(test_data),
             content_type='application/json'
         )
-        print(response.data)
+        data = response.data
+
+        # Ensure same number of entries
+        actual_message_count = LearningAssistantMessage.objects.count()
+        self.assertEqual(len(data), actual_message_count)
+
+        # Ensure values are as expected
+        actual_message = LearningAssistantMessage.objects.get(course_id=self.course_id)
+        self.assertEqual(data[0]['role'], actual_message.role)
+        self.assertEqual(data[0]['content'], actual_message.content)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -305,7 +305,13 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
     @patch('learning_assistant.views.get_course_id')
-    def test_learning_message_history_view_get(self, mock_get_course_id, mock_mode, mock_enrollment, mock_role, mock_waffle):
+    def test_learning_message_history_view_get(self,
+                                               mock_get_course_id,
+                                               mock_mode,
+                                               mock_enrollment,
+                                               mock_role,
+                                               mock_waffle
+                                               ):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -305,13 +305,14 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
     @patch('learning_assistant.views.get_course_id')
-    def test_learning_message_history_view_get(self,
-                                               mock_get_course_id,
-                                               mock_mode,
-                                               mock_enrollment,
-                                               mock_role,
-                                               mock_waffle
-                                               ):
+    def test_learning_message_history_view_get(
+        self,
+        mock_get_course_id,
+        mock_mode,
+        mock_enrollment,
+        mock_role,
+        mock_waffle
+    ):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/COSMO-434

Add GET endpoint to learning-assistant to retrieve message history for a user/course combination.
- Should get messages by user/course combination
- Should add query parameter to limit the amount of messages we receive