### PR TITLE
chore: Release bump to v4.4.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,19 @@ Change Log
 Unreleased
 **********
 
+4.4.4 - 2024-11-06
+******************
+* Fixed Learning Assistant History endpoint
+* Added timestamp to the Learning Assistant History payload
+
+4.4.3 - 2024-11-06
+******************
+* Fixed package version
+
+4.4.2 - 2024-11-04
+******************
+* Added chat messages to the DB
+
 4.4.1 - 2024-10-31
 ******************
 * Add management command to remove expired messages

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.4.3'
+__version__ = '4.4.4'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This release contains a Learning Assistant History endpoint fix.