### PR TITLE
feat: Added timestamp to Learning Assistant History response

### DIFF
--- a/learning_assistant/serializers.py
+++ b/learning_assistant/serializers.py
@@ -13,6 +13,19 @@ class MessageSerializer(serializers.Serializer):  # pylint: disable=abstract-met
 
     role = serializers.CharField(required=True)
     content = serializers.CharField(required=True)
+    timestamp = serializers.DateTimeField(required=False, source='created')
+
+    class Meta:
+        """
+        Serializer metadata.
+        """
+
+        model = LearningAssistantMessage
+        fields = (
+            'role',
+            'content',
+            'timestamp',
+        )
 
     def validate_role(self, value):
         """

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -365,3 +365,4 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
         actual_message = LearningAssistantMessage.objects.get(course_id=self.course_id)
         self.assertEqual(data[0]['role'], actual_message.role)
         self.assertEqual(data[0]['content'], actual_message.content)
+        self.assertEqual(data[0]['timestamp'], actual_message.created.isoformat())


### PR DESCRIPTION
In the frontend we are already using the timestamp of the message (although not really showing it).
Instead of making it up on the frontend, I think it's a good moment to add it since it's valuable information for the future.