### PR TITLE
fix: Updated Learning Assistant History payload to return in ascending order

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Change Log
 
 Unreleased
 **********
+* Updated Learning Assistant History payload to return in ascending order
 
 4.4.4 - 2024-11-06
 ******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 **********
+
+4.4.5 - 2024-11-12
+******************
 * Updated Learning Assistant History payload to return in ascending order
 
 4.4.4 - 2024-11-06

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.4.4'
+__version__ = '4.4.5'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -217,6 +217,10 @@ def get_message_history(courserun_key, user, message_count):
 
     Returns a number of messages equal to the message_count value.
     """
+    # Explanation over the double reverse: This fetches the last message_count elements ordered by creating order DESC.
+    # Slicing the list in the model is an equivalent of adding LIMIT on the query.
+    # The result is the last chat messages for that user and course but in inversed order, so in order to flip them
+    # its first turn into a list and then reversed.
     message_history = list(LearningAssistantMessage.objects.filter(
         course_id=courserun_key, user=user).order_by('-created')[:message_count])[::-1]
     return message_history

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -217,6 +217,6 @@ def get_message_history(courserun_key, user, message_count):
 
     Returns a number of messages equal to the message_count value.
     """
-    message_history = LearningAssistantMessage.objects.filter(
-        course_id=courserun_key, user=user).order_by('-created')[:message_count]
+    message_history = list(LearningAssistantMessage.objects.filter(
+        course_id=courserun_key, user=user).order_by('-created')[:message_count])[::-1]
     return message_history

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -236,6 +236,6 @@ class LearningAssistantMessageHistoryView(APIView):
         user = request.user
 
         message_count = int(request.GET.get('message_count', 50))
-        message_history = get_message_history(courserun_key, user, message_count)
+        message_history = reversed(list(get_message_history(courserun_key, user, message_count)))  # Reversing order
         data = MessageSerializer(message_history, many=True).data
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -236,6 +236,6 @@ class LearningAssistantMessageHistoryView(APIView):
         user = request.user
 
         message_count = int(request.GET.get('message_count', 50))
-        message_history = reversed(list(get_message_history(courserun_key, user, message_count)))  # Reversing order
+        message_history = get_message_history(courserun_key, user, message_count)
         data = MessageSerializer(message_history, many=True).data
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -365,8 +365,8 @@ class GetMessageHistoryTests(TestCase):
 
         return_value = get_message_history(self.course_key, self.user, message_count)
 
-        expected_value = LearningAssistantMessage.objects.filter(
-            course_id=self.course_key, user=self.user).order_by('-created')[:message_count]
+        expected_value = list(LearningAssistantMessage.objects.filter(
+            course_id=self.course_key, user=self.user).order_by('-created')[:message_count])[::-1]
 
         # Ensure same number of entries
         self.assertEqual(len(return_value), len(expected_value))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -374,7 +374,7 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
         self.assertEqual(len(data), db_messages_count)
 
         # Ensure values are as expected
-        for i, expected in enumerate(db_messages):
-            self.assertEqual(expected.role, data[i]['role'])
-            self.assertEqual(expected.content, data[i]['content'])
-            self.assertEqual(expected.created.isoformat(), data[i]['timestamp'])
+        for i, message in enumerate(data):
+            self.assertEqual(message['role'], db_messages[i].role)
+            self.assertEqual(message['content'], db_messages[i].content)
+            self.assertEqual(message['timestamp'], db_messages[i].created.isoformat())


### PR DESCRIPTION
We want the endpoint to return the chat history in ascending order by `timestamp` (creation datetime).