### PR TITLE
feat: add audit gate to CourseChatView

### DIFF
--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -240,20 +240,15 @@ def check_if_audit_trial_is_expired(user, upgrade_deadline):
     if DAYS_SINCE_UPGRADE_DEADLINE >= timedelta(days=0):
         return True
 
-    audit_trial, created = LearningAssistantAuditTrial.objects.get_or_create(
+    audit_trial, _ = LearningAssistantAuditTrial.objects.get_or_create(
         user=user,
         defaults={
             "start_date": datetime.now(),
         },
     )
 
-    # If the trial was just created, then it definitely isn't expired, so return False
-    if created:
-        return False
-
     # If the user's trial is past its expiry date, return "True" for expired. Else, return False
     DAYS_SINCE_TRIAL_START_DATE = datetime.now() - audit_trial.start_date
-    print("DAYS_SINCE_TRIAL_START_DATE:", DAYS_SINCE_TRIAL_START_DATE)
-    if DAYS_SINCE_TRIAL_START_DATE > timedelta(days=AUDIT_TRIAL_MAX_DAYS):
+    if DAYS_SINCE_TRIAL_START_DATE >= timedelta(days=AUDIT_TRIAL_MAX_DAYS):
         return True
     return False

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -231,7 +231,7 @@ def get_message_history(courserun_key, user, message_count):
     return message_history
 
 
-def check_if_audit_trial_is_expired(user, upgrade_deadline):
+def audit_trial_is_expired(user, upgrade_deadline):
     """
     Given a user (User), get or create the corresponding LearningAssistantAuditTrial trial object.
     """
@@ -249,6 +249,4 @@ def check_if_audit_trial_is_expired(user, upgrade_deadline):
 
     # If the user's trial is past its expiry date, return "True" for expired. Else, return False
     DAYS_SINCE_TRIAL_START_DATE = datetime.now() - audit_trial.start_date
-    if DAYS_SINCE_TRIAL_START_DATE >= timedelta(days=AUDIT_TRIAL_MAX_DAYS):
-        return True
-    return False
+    return DAYS_SINCE_TRIAL_START_DATE >= timedelta(days=AUDIT_TRIAL_MAX_DAYS)

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -231,10 +231,15 @@ def get_message_history(courserun_key, user, message_count):
     return message_history
 
 
-def check_if_audit_trial_is_expired(user):
+def check_if_audit_trial_is_expired(user, upgrade_deadline):
     """
     Given a user (User), get or create the corresponding LearningAssistantAuditTrial trial object.
     """
+    # If the upgrade deadline has passed, return "True" for expired
+    DAYS_SINCE_UPGRADE_DEADLINE = datetime.now() - upgrade_deadline
+    if DAYS_SINCE_UPGRADE_DEADLINE >= timedelta(days=0):
+        return True
+
     audit_trial, created = LearningAssistantAuditTrial.objects.get_or_create(
         user=user,
         defaults={
@@ -246,8 +251,9 @@ def check_if_audit_trial_is_expired(user):
     if created:
         return False
 
-    # If the user's trial is expired, return True. Else, return False
+    # If the user's trial is past its expiry date, return "True" for expired. Else, return False
     DAYS_SINCE_TRIAL_START_DATE = datetime.now() - audit_trial.start_date
+    print("DAYS_SINCE_TRIAL_START_DATE:", DAYS_SINCE_TRIAL_START_DATE)
     if DAYS_SINCE_TRIAL_START_DATE > timedelta(days=AUDIT_TRIAL_MAX_DAYS):
         return True
     return False

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -1,6 +1,12 @@
 """
 Constants for the learning_assistant app.
 """
+
+try:
+    from common.djangoapps.course_modes.models import CourseMode
+except ImportError:
+    pass
+
 # Pulled from edx-platform. Will correctly capture both old- and new-style
 # course ID strings.
 INTERNAL_COURSE_KEY_PATTERN = r'([^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -1,12 +1,6 @@
 """
 Constants for the learning_assistant app.
 """
-
-try:
-    from common.djangoapps.course_modes.models import CourseMode
-except ImportError:
-    pass
-
 # Pulled from edx-platform. Will correctly capture both old- and new-style
 # course ID strings.
 INTERNAL_COURSE_KEY_PATTERN = r'([^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'

--- a/learning_assistant/constants.py
+++ b/learning_assistant/constants.py
@@ -14,3 +14,5 @@ CATEGORY_TYPE_MAP = {
     "html": "TEXT",
     "video": "VIDEO",
 }
+
+AUDIT_TRIAL_MAX_DAYS = 14

--- a/learning_assistant/platform_imports.py
+++ b/learning_assistant/platform_imports.py
@@ -8,7 +8,7 @@ cannot be imported normally.
 
 def get_text_transcript(video_block):
     """Get the transcript for a video block in text format, or None."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from xmodule.exceptions import NotFoundError
     from xmodule.video_block.transcripts_utils import get_transcript
     try:
@@ -21,28 +21,28 @@ def get_text_transcript(video_block):
 
 def get_single_block(request, user_id, course_id, usage_key_string, course=None):
     """Load a single xblock."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from lms.djangoapps.courseware.block_render import load_single_xblock
     return load_single_xblock(request, user_id, course_id, usage_key_string, course)
 
 
 def traverse_block_pre_order(start_node, get_children, filter_func=None):
     """Traverse a DAG or tree in pre-order."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from openedx.core.lib.graph_traversals import traverse_pre_order
     return traverse_pre_order(start_node, get_children, filter_func)
 
 
 def block_leaf_filter(block):
     """Return only leaf nodes."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from openedx.core.lib.graph_traversals import leaf_filter
     return leaf_filter(block)
 
 
 def block_get_children(block):
     """Return children of a given block."""
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from openedx.core.lib.graph_traversals import get_children
     return get_children(block)
 
@@ -54,7 +54,7 @@ def get_cache_course_run_data(course_run_id, fields):
     This function makes use of the course run cache in the LMS, which caches data from the discovery service. This is
     necessary because only the discovery service stores the relation between courseruns and courses.
     """
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from openedx.core.djangoapps.catalog.utils import get_course_run_data
     return get_course_run_data(course_run_id, fields)
 
@@ -66,7 +66,7 @@ def get_cache_course_data(course_id, fields):
     This function makes use of the course cache in the LMS, which caches data from the discovery service. This is
     necessary because only the discovery service stores course skills data.
     """
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from openedx.core.djangoapps.catalog.utils import get_course_data
     return get_course_data(course_id, fields)
 
@@ -82,6 +82,6 @@ def get_user_role(user, course_key):
     Returns:
         * str: the user's role
     """
-    # pylint: disable=import-error, import-outside-toplevel
+    # pylint: disable=import-outside-toplevel
     from lms.djangoapps.courseware.access import get_user_role as platform_get_user_role
     return platform_get_user_role(user, course_key)

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -44,55 +44,10 @@ class CourseChatView(APIView):
     authentication_classes = (SessionAuthentication, JwtAuthentication,)
     permission_classes = (IsAuthenticated,)
 
-    def post(self, request, course_run_id):
+    def _get_next_message(self, request, courserun_key, course_run_id):
         """
-        Given a course run ID, retrieve a chat response for that course.
-
-        Expected POST data: {
-            [
-                {'role': 'user', 'content': 'What is 2+2?'},
-                {'role': 'assistant', 'content': '4'}
-            ]
-        }
+        Generate the next message to be returned by the learning assistant.
         """
-        try:
-            courserun_key = CourseKey.from_string(course_run_id)
-        except InvalidKeyError:
-            return Response(
-                status=http_status.HTTP_400_BAD_REQUEST,
-                data={'detail': 'Course ID is not a valid course ID.'}
-            )
-
-        if not learning_assistant_enabled(courserun_key):
-            return Response(
-                status=http_status.HTTP_403_FORBIDDEN,
-                data={'detail': 'Learning assistant not enabled for course.'}
-            )
-
-        # If user does not have a verified enrollment record, or is not staff, they should not have full access
-        user_role = get_user_role(request.user, courserun_key)
-        enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
-        enrollment_mode = enrollment_object.mode if enrollment_object else None
-        if (
-            # NOTE: Will there ever be a case where the user has a course mod that's
-            # in neither VERIFIED_MODES nor AUDIT_MODES that we need to worry about?
-            enrollment_mode not in CourseMode.VERIFIED_MODES
-            and enrollment_mode in CourseMode.AUDIT_MODES
-            and not user_role_is_staff(user_role)
-        ):
-            course_mode = CourseMode.objects.get(course=courserun_key)
-            upgrade_deadline = course_mode.expiration_datetime()
-
-            # If user has an audit enrollment record, get or create their trial
-            user_audit_trial_expired = audit_trial_is_expired(request.user, upgrade_deadline)
-            if user_audit_trial_expired:
-                return Response(
-                    status=http_status.HTTP_403_FORBIDDEN,
-                    data={'detail': 'Must be staff or have valid enrollment.'}
-                )
-
-        unit_id = request.query_params.get('unit_id')
-
         message_list = request.data
 
         # Check that the last message in the list corresponds to a user
@@ -127,8 +82,8 @@ class CourseChatView(APIView):
         )
 
         course_id = get_course_id(course_run_id)
-
         template_string = getattr(settings, 'LEARNING_ASSISTANT_PROMPT_TEMPLATE', '')
+        unit_id = request.query_params.get('unit_id')
 
         prompt_template = render_prompt_template(
             request, request.user.id, course_run_id, unit_id, course_id, template_string
@@ -139,6 +94,72 @@ class CourseChatView(APIView):
             save_chat_message(courserun_key, user_id, LearningAssistantMessage.ASSISTANT_ROLE, message['content'])
 
         return Response(status=status_code, data=message)
+
+    def post(self, request, course_run_id):
+        """
+        Given a course run ID, retrieve a chat response for that course.
+
+        Expected POST data: {
+            [
+                {'role': 'user', 'content': 'What is 2+2?'},
+                {'role': 'assistant', 'content': '4'}
+            ]
+        }
+        """
+        try:
+            courserun_key = CourseKey.from_string(course_run_id)
+        except InvalidKeyError:
+            return Response(
+                status=http_status.HTTP_400_BAD_REQUEST,
+                data={'detail': 'Course ID is not a valid course ID.'}
+            )
+
+        if not learning_assistant_enabled(courserun_key):
+            return Response(
+                status=http_status.HTTP_403_FORBIDDEN,
+                data={'detail': 'Learning assistant not enabled for course.'}
+            )
+
+        # If user does not have a verified enrollment record, or is not staff, they should not have full access
+        user_role = get_user_role(request.user, courserun_key)
+        enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
+        enrollment_mode = enrollment_object.mode if enrollment_object else None
+
+        print("\nenrollment_mode:", enrollment_mode)
+        # If the user is in a verified course mode or is staff, return the next message
+        if (
+            # Here we include CREDIT_MODE and NO_ID_PROFESSIONAL_MODE, as CourseMode.VERIFIED_MODES on its own
+            # doesn't match what we count as "verified modes" in the frontend component.
+            enrollment_mode in CourseMode.VERIFIED_MODES + CourseMode.CREDIT_MODE + CourseMode.NO_ID_PROFESSIONAL_MODE
+            or user_role_is_staff(user_role)
+        ):
+            print("\n\nVERIFIED\n")
+            return self._get_next_message(request, courserun_key, course_run_id)
+
+        # If user has an audit enrollment record, get or create their trial. If the trial is not expired, return the
+        # next message. Otherwise, return 403
+        elif enrollment_mode in CourseMode.UPSELL_TO_VERIFIED_MODES:  # AUDIT, HONOR
+            print("\n\nAUDIT\n")
+            course_mode = CourseMode.objects.get(course=courserun_key)
+            upgrade_deadline = course_mode.expiration_datetime()
+
+            user_audit_trial_expired = audit_trial_is_expired(request.user, upgrade_deadline)
+            if user_audit_trial_expired:
+                return Response(
+                    status=http_status.HTTP_403_FORBIDDEN,
+                    data={'detail': 'The audit trial for this user has expired.'}
+                )
+            else:
+                return self._get_next_message(request, courserun_key, course_run_id)
+
+        # If user has a course mode that is not verified & not meant to access to the learning assistant, return 403
+        # This covers the other course modes: UNPAID_EXECUTIVE_EDUCATION & UNPAID_BOOTCAMP
+        else:
+            print("\n\nHUH????\n")
+            return Response(
+                status=http_status.HTTP_403_FORBIDDEN,
+                data={'detail': 'Must be staff or have valid enrollment.'}
+            )
 
 
 class LearningAssistantEnabledView(APIView):

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -81,7 +81,7 @@ class CourseChatView(APIView):
             and not user_role_is_staff(user_role)
         ):
             # If user has an audit enrollment record, get or create their trial
-            user_audit_trial_expired = check_if_audit_trial_is_expired(user_id=request.user.id)
+            user_audit_trial_expired = check_if_audit_trial_is_expired(user=request.user)
             if user_audit_trial_expired:
                 return Response(
                     status=http_status.HTTP_403_FORBIDDEN,

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -80,8 +80,12 @@ class CourseChatView(APIView):
             and enrollment_mode in CourseMode.AUDIT_MODES
             and not user_role_is_staff(user_role)
         ):
+            # TODO: Add logic to make sure upgrade deadline has not passed.
+            course_mode = CourseMode.objects.get(course=courserun_key)
+            upgrade_deadline = course_mode.expiration_datetime()
+
             # If user has an audit enrollment record, get or create their trial
-            user_audit_trial_expired = check_if_audit_trial_is_expired(user=request.user)
+            user_audit_trial_expired = check_if_audit_trial_is_expired(request.user, upgrade_deadline)
             if user_audit_trial_expired:
                 return Response(
                     status=http_status.HTTP_403_FORBIDDEN,

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -21,7 +21,7 @@ except ImportError:
     pass
 
 from learning_assistant.api import (
-    check_if_audit_trial_is_expired,
+    audit_trial_is_expired,
     get_course_id,
     get_message_history,
     learning_assistant_enabled,
@@ -80,12 +80,11 @@ class CourseChatView(APIView):
             and enrollment_mode in CourseMode.AUDIT_MODES
             and not user_role_is_staff(user_role)
         ):
-            # TODO: Add logic to make sure upgrade deadline has not passed.
             course_mode = CourseMode.objects.get(course=courserun_key)
             upgrade_deadline = course_mode.expiration_datetime()
 
             # If user has an audit enrollment record, get or create their trial
-            user_audit_trial_expired = check_if_audit_trial_is_expired(request.user, upgrade_deadline)
+            user_audit_trial_expired = audit_trial_is_expired(request.user, upgrade_deadline)
             if user_audit_trial_expired:
                 return Response(
                     status=http_status.HTTP_403_FORBIDDEN,

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -125,7 +125,6 @@ class CourseChatView(APIView):
         enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)
         enrollment_mode = enrollment_object.mode if enrollment_object else None
 
-        print("\nenrollment_mode:", enrollment_mode)
         # If the user is in a verified course mode or is staff, return the next message
         if (
             # Here we include CREDIT_MODE and NO_ID_PROFESSIONAL_MODE, as CourseMode.VERIFIED_MODES on its own
@@ -133,13 +132,11 @@ class CourseChatView(APIView):
             enrollment_mode in CourseMode.VERIFIED_MODES + CourseMode.CREDIT_MODE + CourseMode.NO_ID_PROFESSIONAL_MODE
             or user_role_is_staff(user_role)
         ):
-            print("\n\nVERIFIED\n")
             return self._get_next_message(request, courserun_key, course_run_id)
 
         # If user has an audit enrollment record, get or create their trial. If the trial is not expired, return the
         # next message. Otherwise, return 403
         elif enrollment_mode in CourseMode.UPSELL_TO_VERIFIED_MODES:  # AUDIT, HONOR
-            print("\n\nAUDIT\n")
             course_mode = CourseMode.objects.get(course=courserun_key)
             upgrade_deadline = course_mode.expiration_datetime()
 
@@ -155,7 +152,6 @@ class CourseChatView(APIView):
         # If user has a course mode that is not verified & not meant to access to the learning assistant, return 403
         # This covers the other course modes: UNPAID_EXECUTIVE_EDUCATION & UNPAID_BOOTCAMP
         else:
-            print("\n\nHUH????\n")
             return Response(
                 status=http_status.HTTP_403_FORBIDDEN,
                 data={'detail': 'Must be staff or have valid enrollment.'}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 Test cases for the learning-assistant api module.
 """
 import itertools
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import ddt
@@ -16,6 +17,7 @@ from learning_assistant.api import (
     _extract_block_contents,
     _get_children_contents,
     _leaf_filter,
+    check_if_audit_trial_is_expired,
     get_block_content,
     get_message_history,
     learning_assistant_available,
@@ -24,8 +26,13 @@ from learning_assistant.api import (
     save_chat_message,
     set_learning_assistant_enabled,
 )
+from learning_assistant.constants import AUDIT_TRIAL_MAX_DAYS
 from learning_assistant.data import LearningAssistantCourseEnabledData
-from learning_assistant.models import LearningAssistantCourseEnabled, LearningAssistantMessage
+from learning_assistant.models import (
+    LearningAssistantAuditTrial,
+    LearningAssistantCourseEnabled,
+    LearningAssistantMessage,
+)
 
 fake_transcript = 'This is the text version from the transcript'
 User = get_user_model()
@@ -241,6 +248,7 @@ class TestLearningAssistantCourseEnabledApi(TestCase):
     """
     Test suite for save_chat_message.
     """
+
     def setUp(self):
         super().setUp()
 
@@ -473,3 +481,35 @@ class GetMessageHistoryTests(TestCase):
             self.assertEqual(return_value.user, expected_value[i].user)
             self.assertEqual(return_value.role, expected_value[i].role)
             self.assertEqual(return_value.content, expected_value[i].content)
+
+
+@ddt.ddt
+class CheckIfAuditTrialIsExpiredTests(TestCase):
+    """
+    Test suite for check_if_audit_trial_is_expired.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course_key = CourseKey.from_string('course-v1:edx+fake+1')
+        self.user = User(username='tester', email='tester@test.com')
+        self.user.save()
+
+        self.role = 'verified'
+
+    def test_check_if_audit_trial_is_expired_audit_trial_created(self):
+        self.assertEqual(check_if_audit_trial_is_expired(self.user), False)
+
+    def test_check_if_audit_trial_is_expired_audit_trial_expired(self):
+        LearningAssistantAuditTrial.objects.create(
+            user=self.user,
+            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS + 1),
+        )
+        self.assertEqual(check_if_audit_trial_is_expired(self.user), True)
+
+    def test_check_if_audit_trial_is_expired_audit_trial_unexpired(self):
+        LearningAssistantAuditTrial.objects.create(
+            user=self.user,
+            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS - 0.99),
+        )
+        self.assertEqual(check_if_audit_trial_is_expired(self.user), False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -502,9 +502,6 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
         upgrade_deadline = datetime.now() - timedelta(days=1)  # yesterday
         self.assertEqual(check_if_audit_trial_is_expired(self.user, upgrade_deadline), True)
 
-    def test_check_if_audit_trial_is_expired_audit_trial_created(self):
-        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), False)
-
     def test_check_if_audit_trial_is_expired_audit_trial_expired(self):
         LearningAssistantAuditTrial.objects.create(
             user=self.user,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,7 +17,7 @@ from learning_assistant.api import (
     _extract_block_contents,
     _get_children_contents,
     _leaf_filter,
-    check_if_audit_trial_is_expired,
+    audit_trial_is_expired,
     get_block_content,
     get_message_history,
     learning_assistant_available,
@@ -486,7 +486,7 @@ class GetMessageHistoryTests(TestCase):
 @ddt.ddt
 class CheckIfAuditTrialIsExpiredTests(TestCase):
     """
-    Test suite for check_if_audit_trial_is_expired.
+    Test suite for audit_trial_is_expired.
     """
 
     def setUp(self):
@@ -500,18 +500,18 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
 
     def test_check_if_past_upgrade_deadline(self):
         upgrade_deadline = datetime.now() - timedelta(days=1)  # yesterday
-        self.assertEqual(check_if_audit_trial_is_expired(self.user, upgrade_deadline), True)
+        self.assertEqual(audit_trial_is_expired(self.user, upgrade_deadline), True)
 
-    def test_check_if_audit_trial_is_expired_audit_trial_expired(self):
+    def test_audit_trial_is_expired_audit_trial_expired(self):
         LearningAssistantAuditTrial.objects.create(
             user=self.user,
             start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS + 1),  # 1 day more than trial deadline
         )
-        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), True)
+        self.assertEqual(audit_trial_is_expired(self.user, self.upgrade_deadline), True)
 
-    def test_check_if_audit_trial_is_expired_audit_trial_unexpired(self):
+    def test_audit_trial_is_expired_audit_trial_unexpired(self):
         LearningAssistantAuditTrial.objects.create(
             user=self.user,
             start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS - 0.99),  # 0.99 days less than deadline
         )
-        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), False)
+        self.assertEqual(audit_trial_is_expired(self.user, self.upgrade_deadline), False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -496,20 +496,25 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
         self.user.save()
 
         self.role = 'verified'
+        self.upgrade_deadline = datetime.now() + timedelta(days=1)  # 1 day from now
+
+    def test_check_if_past_upgrade_deadline(self):
+        upgrade_deadline = datetime.now() - timedelta(days=1)  # yesterday
+        self.assertEqual(check_if_audit_trial_is_expired(self.user, upgrade_deadline), True)
 
     def test_check_if_audit_trial_is_expired_audit_trial_created(self):
-        self.assertEqual(check_if_audit_trial_is_expired(self.user), False)
+        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), False)
 
     def test_check_if_audit_trial_is_expired_audit_trial_expired(self):
         LearningAssistantAuditTrial.objects.create(
             user=self.user,
-            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS + 1),
+            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS + 1),  # 1 day more than trial deadline
         )
-        self.assertEqual(check_if_audit_trial_is_expired(self.user), True)
+        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), True)
 
     def test_check_if_audit_trial_is_expired_audit_trial_unexpired(self):
         LearningAssistantAuditTrial.objects.create(
             user=self.user,
-            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS - 0.99),
+            start_date=datetime.now() - timedelta(days=AUDIT_TRIAL_MAX_DAYS - 0.99),  # 0.99 days less than deadline
         )
-        self.assertEqual(check_if_audit_trial_is_expired(self.user), False)
+        self.assertEqual(check_if_audit_trial_is_expired(self.user, self.upgrade_deadline), False)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -108,7 +108,7 @@ class CourseChatViewTests(LoggedInTestCase):
         response = self.client.post(reverse('chat', kwargs={'course_run_id': self.course_id}))
         self.assertEqual(response.status_code, 403)
 
-    @patch('learning_assistant.views.check_if_audit_trial_is_expired')
+    @patch('learning_assistant.views.audit_trial_is_expired')
     @patch('learning_assistant.views.learning_assistant_enabled')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -135,8 +135,7 @@ class CourseChatViewTests(LoggedInTestCase):
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment.get_enrollment')
     @patch('learning_assistant.views.CourseMode')
-    def test_audit_trial_expired(self, mock_mode, mock_enrollment, mock_role,
-                                                           mock_waffle, mock_trial_expired):
+    def test_audit_trial_expired(self, mock_mode, mock_enrollment, mock_role, mock_waffle, mock_trial_expired):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,9 @@
 """
 Tests for the learning assistant views.
 """
-import datetime
 import json
 import sys
+from datetime import date, datetime, timedelta
 from importlib import import_module
 from unittest.mock import MagicMock, call, patch
 
@@ -119,6 +119,8 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
         mock_mode.AUDIT_MODES = ['audit']
+        mock_mode.objects.get.return_value = MagicMock()
+        mock_mode.expiration_datetime.return_value = datetime.now() - timedelta(days=1)
         mock_enrollment.return_value = MagicMock(mode='audit')
         mock_expired.return_value = True
 
@@ -340,7 +342,7 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
             user=self.user,
             role='staff',
             content='Older message',
-            created=datetime.date(2024, 10, 1)
+            created=date(2024, 10, 1)
         )
 
         LearningAssistantMessage.objects.create(
@@ -348,7 +350,7 @@ class LearningAssistantMessageHistoryViewTests(LoggedInTestCase):
             user=self.user,
             role='staff',
             content='Newer message',
-            created=datetime.date(2024, 10, 3)
+            created=date(2024, 10, 3)
         )
 
         db_messages = LearningAssistantMessage.objects.all().order_by('created')


### PR DESCRIPTION
Ticket: https://2u-internal.atlassian.net/browse/COSMO-568

Add functionality get or create an audit trial if the user is an audit learner.

- If the user’s course enrollment mode (CourseMode) is audit:
  - Get (or create if none exists*) the user’s LearningAssistantAuditTrial (using python API logic created here: https://2u-internal.atlassian.net/browse/COSMO-567 )
  - Get remaining days remaining in their Xpert LA audit trial, using endpoint created above
  - If remaining days is 0, user should not have access and should return 403

- When an audit learner first sends a message in Xpert LA, we’ll need to create a LearningAssistantAuditTrial to save the start date for the audit trial