### PR TITLE
fix: Gates the chat history endpoint behind a waffle flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.4.6 - 2024-11-22
+******************
+* Gates the chat history endpoint behind a waffle flag
+
 4.4.5 - 2024-11-12
 ******************
 * Updated Learning Assistant History payload to return in ascending order

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.4.5'
+__version__ = '4.4.6'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -247,6 +247,10 @@ class LearningAssistantMessageHistoryView(APIView):
                 data={'detail': 'Learning assistant not enabled for course.'}
             )
 
+        # If chat history is disabled, we return no messages as response.
+        if not chat_history_enabled(courserun_key):
+            return Response(status=http_status.HTTP_200_OK, data=[])
+
         # If user does not have an enrollment record, or is not staff, they should not have access
         user_role = get_user_role(request.user, courserun_key)
         enrollment_object = CourseEnrollment.get_enrollment(request.user, courserun_key)


### PR DESCRIPTION
Currently, the only logic for the chat history behind the feature flag `learning_assistant.enable_chat_history` is the saving of the messages.

If we want to disable the feature, the chats are no longer being saved but the existing ones will still be returned by the learning Assistant Message History endpoint.

This update makes sure that if the flag for the chat history is disabled, the endpoint would just return an empty list.