### PR TITLE
fix: course mode list concatenation issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,9 +14,14 @@ Change Log
 Unreleased
 **********
 
+4.4.7 - 2024-11-25
+******************
+* Fixes the Course Chat View CourseMode concatenation issue
+
 4.4.6 - 2024-11-22
 ******************
 * Gates the chat history endpoint behind a waffle flag
+* Add LearningAssistantAuditTrial model
 
 4.4.5 - 2024-11-12
 ******************

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.4.6'
+__version__ = '4.4.7'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -129,7 +129,8 @@ class CourseChatView(APIView):
         if (
             # Here we include CREDIT_MODE and NO_ID_PROFESSIONAL_MODE, as CourseMode.VERIFIED_MODES on its own
             # doesn't match what we count as "verified modes" in the frontend component.
-            enrollment_mode in CourseMode.VERIFIED_MODES + CourseMode.CREDIT_MODE + CourseMode.NO_ID_PROFESSIONAL_MODE
+            enrollment_mode in CourseMode.VERIFIED_MODES + CourseMode.CREDIT_MODES
+            + [CourseMode.NO_ID_PROFESSIONAL_MODE]
             or user_role_is_staff(user_role)
         ):
             return self._get_next_message(request, courserun_key, course_run_id)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -140,8 +140,8 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
-        mock_mode.CREDIT_MODE = ['credit']
-        mock_mode.NO_ID_PROFESSIONAL_MODE = ['no-id']
+        mock_mode.CREDIT_MODES = ['credit']
+        mock_mode.NO_ID_PROFESSIONAL_MODE = 'no-id'
         mock_mode.UPSELL_TO_VERIFIED_MODES = ['audit']
         mock_mode.objects.get.return_value = MagicMock()
         mock_mode.expiration_datetime.return_value = datetime.now() - timedelta(days=1)
@@ -165,8 +165,8 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
-        mock_mode.CREDIT_MODE = ['credit']
-        mock_mode.NO_ID_PROFESSIONAL_MODE = ['no-id']
+        mock_mode.CREDIT_MODES = ['credit']
+        mock_mode.NO_ID_PROFESSIONAL_MODE = 'no-id'
         mock_mode.UPSELL_TO_VERIFIED_MODES = ['audit']
         mock_mode.objects.get.return_value = MagicMock()
         mock_mode.expiration_datetime.return_value = datetime.now() - timedelta(days=1)
@@ -206,8 +206,8 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_waffle.return_value = True
         mock_role.return_value = 'student'
         mock_mode.VERIFIED_MODES = ['verified']
-        mock_mode.CREDIT_MODE = ['credit']
-        mock_mode.NO_ID_PROFESSIONAL_MODE = ['no-id']
+        mock_mode.CREDIT_MODES = ['credit']
+        mock_mode.NO_ID_PROFESSIONAL_MODE = 'no-id'
         mock_mode.UPSELL_TO_VERIFIED_MODES = ['audit']
         mock_enrollment.return_value = MagicMock(mode=enrollment_mode)
         mock_chat_response.return_value = (200, {'role': 'assistant', 'content': 'Something else'})


### PR DESCRIPTION
There was a bug in the course chat view causing learning assistant to fail in stage. The course modes were not being concatenated correctly (string and list concatenation), so this PR updates the course modes that are a string to be listified and also updates tests.