### PR TITLE
fix: use course enrollment instead of course mode to calculate audit trial is expired

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,19 +13,23 @@ Change Log
 
 Unreleased
 **********
+
+4.6.3 - 2025-01-06
+******************
+* Uses CourseEnrollment instead of CourseMode to get the upgrade deadline required to calculate if a learner's audit trial is expired.
 * Updated setup docs
 
-4.6.2 - 2025-12-18
+4.6.2 - 2024-12-18
 ******************
 * Fixed the params for expiration_date in the admin table for audit trial.
 * Add ENABLE_XPERT_AUDIT instructions.
 
-4.6.1 - 2025-12-17
+4.6.1 - 2024-12-17
 ******************
 * Added an admin table for the LearningAssistantAuditTrial model. This table includes an expiration_date valued that is
   calculated based on the start_date.
 
-4.6.0 - 2025-12-10
+4.6.0 - 2024-12-10
 ******************
 * Add an audit_trial_length_days attribute to the response returned by the ChatSummaryView, representing the
   number of days in an audit trial as currently configured. It does not necessarily represent the number of days in the

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.6.2'
+__version__ = '4.6.3'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -156,7 +156,7 @@ class CourseChatView(APIView):
         # next message. Otherwise, return 403
         elif enrollment_mode in CourseMode.UPSELL_TO_VERIFIED_MODES:  # AUDIT, HONOR
             audit_trial = get_or_create_audit_trial(request.user)
-            is_user_audit_trial_expired = audit_trial_is_expired(audit_trial, courserun_key)
+            is_user_audit_trial_expired = audit_trial_is_expired(enrollment_object, audit_trial)
             if is_user_audit_trial_expired:
                 return Response(
                     status=http_status.HTTP_403_FORBIDDEN,
@@ -383,7 +383,7 @@ class LearningAssistantChatSummaryView(APIView):
         has_trial_access = (
             enrollment_mode in valid_trial_access_modes
             and audit_trial
-            and not audit_trial_is_expired(audit_trial, courserun_key)
+            and not audit_trial_is_expired(enrollment_object, audit_trial)
         )
 
         if (


### PR DESCRIPTION
[COSMO-616](https://2u-internal.atlassian.net/browse/COSMO-616)

As I was trying to understand how to set the upgrade deadline (i.e. the topic in standup about prioritizing audit vs. honor), I ran into some questions around CourseEnrollment and CourseMode which might change how [audit_trial_is_expired](https://github.com/edx/learning-assistant/blob/39d2f2185e60b2fe17585f1b636f060c75d20eef/learning_assistant/api.py#L310) is implemented.

**Context**

Currently [audit_trial_is_expired](https://github.com/edx/learning-assistant/blob/39d2f2185e60b2fe17585f1b636f060c75d20eef/learning_assistant/api.py#L310) gets the CourseMode (this is where it gets multiple) using the courserun_key and then uses the expiration_datetime (aka upgrade_deadline) to calculate whether the audit trial is expired

But, the CourseMode [expiration_datetime](https://github.com/openedx/edx-platform/blob/882475dd5e81df717100ae3e54f838c326370494/common/djangoapps/course_modes/models.py#L74) corresponds to the expiration of this course mode. So if "For example, if there is a verified mode that expires on 1/1/2015, then users will be able to upgrade into the verified mode before that date. Once the date passes, users will no longer be able to enroll as verified." This means that for the purpose of the [audit_trial_is_expired](https://github.com/edx/learning-assistant/blob/39d2f2185e60b2fe17585f1b636f060c75d20eef/learning_assistant/api.py#L310), we want to get the upgrade deadline for the verified mode, not for the audit or honor mode which is what we would be doing now, since the learner is an audit learner

**Proposed Solution**

I propose that we use the CourseEnrollment [upgrade_deadline](https://github.com/openedx/edx-platform/blob/master/common/djangoapps/student/models/course_enrollment.py#L1248) to get the upgrade deadline for the course.

This method gets the verified modes (if there are any) and calculates the upgrade deadline, which is what we need for this method.