### PR TITLE
fix: correct params for expiration_date

### DIFF
--- a/learning_assistant/admin.py
+++ b/learning_assistant/admin.py
@@ -26,11 +26,12 @@ class LearningAssistantAuditTrialAdmin(admin.ModelAdmin):
     """
 
     @admin.display(description="Expiration Date")
-    def expiration_date(self, obj):
+    def expiration_date(self):
         """
         Generate the expiration date for the LearningAssistantAuditTrial based on the start_date.
         """
-        return obj.start_date + timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS)
+        # pylint: disable-next=no-member
+        return self.start_date + timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS)
 
     list_display = ('user', 'start_date', expiration_date)
     raw_id_fields = ('user',)


### PR DESCRIPTION
Correction on the parameters for the expiration_date in https://github.com/edx/learning-assistant/pull/145, which is causing the table to error.