### PR TITLE
fix: use django utils timezone to make timezone aware

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.7.1 - 2025-01-09
+******************
+* Use Django utils timezone instead of datetime to get now to prevent naive/aware comparisons.
+
 4.7.0 - 2025-01-07
 ******************
 * Gate use of the Xpert platform v2 endpoint with a waffle flag.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.7.0'
+__version__ = '4.7.1'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -1,13 +1,13 @@
 """
 Library for the learning_assistant app.
 """
-import datetime
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
+from django.utils import timezone
 from edx_django_utils.cache import get_cache_key
 from jinja2 import BaseLoader, Environment
 from opaque_keys import InvalidKeyError
@@ -291,7 +291,7 @@ def get_or_create_audit_trial(user):
     audit_trial, _ = LearningAssistantAuditTrial.objects.get_or_create(
         user=user,
         defaults={
-            "start_date": datetime.now(),
+            "start_date": timezone.now(),
         },
     )
 
@@ -314,7 +314,7 @@ def audit_trial_is_expired(enrollment, audit_trial_data):
     * audit_trial_is_expired (boolean): whether the audit trial is expired
     """
     upgrade_deadline = enrollment.upgrade_deadline
-    today = datetime.now(tz=timezone.utc)
+    today = timezone.now()
 
     # If the upgrade deadline has passed, return True for expired. Upgrade deadline is an optional attribute of a
     # CourseEnrollment, so if it's None, then do not return True.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 Test cases for the learning-assistant api module.
 """
 import itertools
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import ddt
@@ -593,15 +593,15 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
     Test suite for audit_trial_is_expired.
     """
 
+    @freeze_time('2024-01-01 00:00:01')
     def setUp(self):
         super().setUp()
         self.course_key = CourseKey.from_string('course-v1:edx+fake+1')
         self.user = User(username='tester', email='tester@test.com')
         self.user.save()
 
-    @freeze_time('2024-01-01 00:00:01 UTC')
     def test_upgrade_deadline_expired(self):
-        today = datetime.now(tz=timezone.utc)
+        today = datetime.now()
         mock_enrollment = MagicMock()
         mock_enrollment.upgrade_deadline = today - timedelta(days=1)  # yesterday
 
@@ -614,9 +614,8 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
 
         self.assertEqual(audit_trial_is_expired(mock_enrollment, audit_trial_data), True)
 
-    @freeze_time('2024-01-01 00:00:01 UTC')
     def test_upgrade_deadline_none(self):
-        today = datetime.now(tz=timezone.utc)
+        today = datetime.now()
         mock_enrollment = MagicMock()
         mock_enrollment.upgrade_deadline = None
 
@@ -642,15 +641,12 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
 
     @ddt.data(
         # exactly the trial deadline
-        datetime(year=2024, month=1, day=1, tzinfo=timezone.utc) -
-        timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS),
+        datetime(year=2024, month=1, day=1) - timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS),
         # 1 day more than trial deadline
-        datetime(year=2024, month=1, day=1, tzinfo=timezone.utc) -
-        timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS + 1),
+        datetime(year=2024, month=1, day=1) - timedelta(days=settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS + 1),
     )
-    @freeze_time('2024-01-01 00:00:01 UTC')
     def test_audit_trial_expired(self, start_date):
-        today = datetime.now(tz=timezone.utc)
+        today = datetime.now()
         mock_enrollment = MagicMock()
         mock_enrollment.upgrade_deadline = today + timedelta(days=1)  # tomorrow
 
@@ -662,9 +658,8 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
 
         self.assertEqual(audit_trial_is_expired(mock_enrollment, audit_trial_data), True)
 
-    @freeze_time('2024-01-01 00:00:01 UTC')
     def test_audit_trial_unexpired(self):
-        today = datetime.now(tz=timezone.utc)
+        today = datetime.now()
         mock_enrollment = MagicMock()
         mock_enrollment.upgrade_deadline = today + timedelta(days=1)  # tomorrow
 


### PR DESCRIPTION
This PR fixes a bug which caused an error in audit_trial_is_expired which was happening due to an incompatible comparison in timezone naive and aware datetimes.

Instead of using datetime.now(), we now use timezone.now() from Django utils which makes timezone aware / naive based on the USE_TZ setting. This changes both the instance of this in audit_trial_is_expired and also in the LearningAssistantAuditTrialData's start_date and expiration_date. 

This ensures consistency in the comparisons.