### PR TITLE
fix: Create release v4.10.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,12 @@ Change Log
 Unreleased
 **********
 
+4.10.1 - 2025-02-19
+*******************
+* Fixes a linting error on the changelog that prevented the previous release.
+
 4.10.0 - 2025-02-19
-******************
+*******************
 * Upgraded Python requirements.
 * Updated Chat Trial Audit gating consistency.
 

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.10.0'
+__version__ = '4.10.1'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
Fixes a linting error on the changelog that prevented the previous release.