### PR TITLE
Update CI and PyPI publish actions to use ubuntu-latest instead of ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ['3.12']
         toxenv: [quality, pii_check, django42]
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**Description**

Ubuntu 20.04 is losing long term support on 05/31/2025, but the Github Ubuntu 20.04 actions runner image will be fully unsupported on 04/01/2025, and deprecation began on 02/01/2025. The issue link is below.

https://github.com/actions/runner-images/issues/11101

This repository uses the Ubuntu 20.04 LTS runner in two Github actions - ci and pypi-publish. As of 03/04/2025 any new runs of these actions fail with the following error.

This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101.

This commit updates the version of the Ubuntu runner from 20.04 to latest.

**Jira**: None.