### PR TITLE
fix: audit trial length defaulting to 14 days in backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 **********
 
+4.10.5 - 2025-03-06
+*******************
+* Fixes a bug where audit trial length was defaulting to 14 days due to missing language preference for Optimizely
+
 4.10.4 - 2025-03-05
 *******************
 * Adds logic to trim down unit content to a maximum length of characters, specified with a Django setting

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.10.4'
+__version__ = '4.10.5'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 import requests
 from django.conf import settings
+from django.utils.translation import get_language
 from optimizely import optimizely
 from requests.exceptions import ConnectTimeout
 from rest_framework import status as http_status
@@ -145,7 +146,9 @@ def get_optimizely_variation(user_id, enrollment_mode):
         variation_key = None
     else:
         optimizely_client = optimizely.Optimizely(sdk_key=settings.OPTIMIZELY_FULLSTACK_SDK_KEY)
-        user = optimizely_client.create_user_context(str(user_id), {'lms_enrollment_mode': enrollment_mode})
+        user = optimizely_client.create_user_context(str(user_id),
+                                                     {'lms_language_preference': get_language(),
+                                                      'lms_enrollment_mode': enrollment_mode})
         decision = user.decide(getattr(settings, 'OPTIMIZELY_LEARNING_ASSISTANT_TRIAL_EXPERIMENT_KEY', ''))
         enabled = decision.enabled
         variation_key = decision.variation_key


### PR DESCRIPTION
[COSMO-682](https://2u-internal.atlassian.net/browse/COSMO-682)

This PR adds lms_language_preference to the Optimizely user context in the backend (this already exists in the frontend), so that the learner is correctly added to the experiment (requires English language users only and audit learners only). 

Then the backend can correctly set the expiration date and trial length, rather than defaulting to 14 days.