### PR TITLE
fix:  Ensure chat response is always returned as a list for XPert chat API compatibility

### DIFF
--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -96,7 +96,11 @@ def get_chat_response(prompt_template, message_list):
                 data=json.dumps(body),
                 timeout=(connect_timeout, read_timeout)
             )
-            chat = response.json()
+            response_json = response.json()
+            if isinstance(response_json, list):
+                chat = response_json
+            else:
+                chat = [response_json]
             response_status = response.status_code
         except (ConnectTimeout, ConnectionError) as e:
             error_message = str(e)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,7 +45,7 @@ class GetChatResponseTests(TestCase):
         self.assertEqual(message, 'Completion endpoint is not defined.')
 
     @responses.activate
-    def test_200_response(self):
+    def test_200_response_single_object(self):
         message_response = {'role': 'assistant', 'content': 'See you later!'}
         responses.add(
             responses.POST,
@@ -56,6 +56,25 @@ class GetChatResponseTests(TestCase):
 
         status_code, message = self.get_response()
         self.assertEqual(status_code, 200)
+        # Single objects should be converted to a list
+        self.assertEqual(message, [message_response])
+
+    @responses.activate
+    def test_200_response_list_object(self):
+        message_response = [
+            {'role': 'assistant', 'content': 'Hello!'},
+            {'role': 'assistant', 'content': 'See you later!'}
+        ]
+        responses.add(
+            responses.POST,
+            settings.CHAT_COMPLETION_API,
+            status=200,
+            body=json.dumps(message_response),
+        )
+
+        status_code, message = self.get_response()
+        self.assertEqual(status_code, 200)
+        # Lists should remain as lists
         self.assertEqual(message, message_response)
 
     @responses.activate
@@ -70,7 +89,8 @@ class GetChatResponseTests(TestCase):
 
         status_code, message = self.get_response()
         self.assertEqual(status_code, 500)
-        self.assertEqual(message, message_response)
+        # Error messages should also be converted to a list
+        self.assertEqual(message, [message_response])
 
     @ddt.data(
         ConnectionError,


### PR DESCRIPTION
**Description:** 
This commit updates the chat response handling logic to ensure that responses from the XPert chat API are consistently returned as a list, regardless of whether the API returns a single object or a list. This change improves compatibility with the latest XPert chat API.

**Key changes:**

1. Modified learning_assistant/utils.py to wrap single object responses in a list.
2. Updated and expanded tests in tests/test_utils.py to verify correct handling for both single objects and list responses, as well as error cases.

**JIRA:**https://2u-internal.atlassian.net/browse/COSMO-700