### PR TITLE
chore: Update version to 4.10.6 and document changes in CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Change Log
 
 Unreleased
 **********
+4.10.6 - 2025-07-01
+*******************
+* XPert chat API responses are uniformly returned as a list, which improves compatibility between the v1 and v2 endpoints.
 
 4.10.5 - 2025-03-06
 *******************

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.10.5'
+__version__ = '4.10.6'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This pull request updates the `learning_assistant` plugin to version `4.10.6` and introduces a change to ensure XPert chat API responses are consistently returned as lists for improved compatibility across endpoints.

Version update:

* Updated the version number from `4.10.5` to `4.10.6`.
* Version update for the changes made in PR https://github.com/edx/learning-assistant/pull/190