### PR TITLE
fix: Simplify chat response handling to return objects as-is instead

### DIFF
--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -96,11 +96,7 @@ def get_chat_response(prompt_template, message_list):
                 data=json.dumps(body),
                 timeout=(connect_timeout, read_timeout)
             )
-            response_json = response.json()
-            if isinstance(response_json, list):
-                chat = response_json
-            else:
-                chat = [response_json]
+            chat = response.json()
             response_status = response.status_code
         except (ConnectTimeout, ConnectionError) as e:
             error_message = str(e)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,8 +56,8 @@ class GetChatResponseTests(TestCase):
 
         status_code, message = self.get_response()
         self.assertEqual(status_code, 200)
-        # Single objects should be converted to a list
-        self.assertEqual(message, [message_response])
+        # Single objects are returned as-is
+        self.assertEqual(message, message_response)
 
     @responses.activate
     def test_200_response_list_object(self):
@@ -74,7 +74,7 @@ class GetChatResponseTests(TestCase):
 
         status_code, message = self.get_response()
         self.assertEqual(status_code, 200)
-        # Lists should remain as lists
+        # Lists are returned as-is
         self.assertEqual(message, message_response)
 
     @responses.activate
@@ -89,8 +89,8 @@ class GetChatResponseTests(TestCase):
 
         status_code, message = self.get_response()
         self.assertEqual(status_code, 500)
-        # Error messages should also be converted to a list
-        self.assertEqual(message, [message_response])
+        # Error messages are returned as-is
+        self.assertEqual(message, message_response)
 
     @ddt.data(
         ConnectionError,


### PR DESCRIPTION
This pull request updates the behavior of the `get_chat_response` function in `learning_assistant/utils.py` and modifies related tests in `tests/test_utils.py`. The main change is the removal of logic that converted single objects and error messages into lists. Instead, the function now returns responses as-is, whether they are single objects or lists.

### Updates to response handling:

* [`learning_assistant/utils.py`](diffhunk://#diff-85a76b6461766a79ab905e2db9fc871540ebe5d443ea846f3fb5d75e229fee6fL99-R99): Simplified the `get_chat_response` function by removing the conditional logic that converted single objects into lists. Responses are now returned in their original format.

### Updates to tests:

* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L59-R60): Updated the `test_200_response_single_object` test to assert that single objects are returned as-is, rather than being converted to lists.
* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L77-R77): Updated the `test_200_response_list_object` test to confirm that lists are returned as-is, with no additional processing.
* [`tests/test_utils.py`](diffhunk://#diff-33c13e0b177bacd2f02e29bcb8aea5b49e7ce34901fd8f41fefb65defba1bd33L92-R93): Updated the `test_non_200_response` test to validate that error messages are returned as-is, rather than being wrapped in a list.…of converting to a list