### PR TITLE
chore: Update version to 4.10.7 and document changes in CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 
 Unreleased
 **********
+4.10.7 - 2025-07-15
+*******************
+* XPert Chat API response will be message object for V1 endpoint and a list of messages for V2 endpoint.
+* Adds a Django setting to control the chat v2 endpoint availability in production
+
 4.10.6 - 2025-07-01
 *******************
 * XPert chat API responses are uniformly returned as a list, which improves compatibility between the v1 and v2 endpoints.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.10.6'
+__version__ = '4.10.7'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name


### PR DESCRIPTION
This pull request updates the version of the `learning_assistant` plugin to `4.10.7` and introduces changes related to the XPert Chat API and its configuration. The most important changes include updating the changelog with details about the new version and modifying the plugin version in the `__init__.py` file.

**Version update and changelog:**

* [`CHANGELOG.rst`](diffhunk://#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43cR16-R20): Added a new entry for version `4.10.7`, dated `2025-07-15`. The entry highlights that the XPert Chat API response will now differ between the V1 and V2 endpoints, and a new Django setting has been added to control the availability of the chat V2 endpoint in production.
* [`learning_assistant/__init__.py`](diffhunk://#diff-4dd156797cd9739b311d0299d6dd75f190a3dc82b1e9d7e02f9ad5df5b5450caL5-R5): Updated the `__version__` variable from `4.10.6` to `4.10.7`.