### PR TITLE
feat: make 14 day trial default for feature rollout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 
 Unreleased
 **********
+
+4.11.0 - 2025-08-08
+******************
+* Replaced the get_audit_trial_length_days utils.py function from with the AUDIT_TRIAL_MAX_DAYS = 14, as the
+  audit trial length will be 14 days going forwards.
+
 4.10.8 - 2025-07-31
 *******************
 * Chat history to support XPert Chat API V2 response with a list of messages.

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.10.8'
+__version__ = '4.11.0'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -12,7 +12,7 @@ from edx_django_utils.cache import get_cache_key
 from jinja2 import BaseLoader, Environment
 from opaque_keys import InvalidKeyError
 
-from learning_assistant.constants import ACCEPTED_CATEGORY_TYPES, CATEGORY_TYPE_MAP
+from learning_assistant.constants import ACCEPTED_CATEGORY_TYPES, AUDIT_TRIAL_MAX_DAYS, CATEGORY_TYPE_MAP
 from learning_assistant.data import LearningAssistantAuditTrialData, LearningAssistantCourseEnabledData
 from learning_assistant.models import (
     LearningAssistantAuditTrial,
@@ -29,7 +29,6 @@ from learning_assistant.platform_imports import (
     traverse_block_pre_order,
 )
 from learning_assistant.text_utils import html_to_text
-from learning_assistant.utils import get_audit_trial_length_days
 
 log = logging.getLogger(__name__)
 User = get_user_model()
@@ -243,7 +242,7 @@ def get_message_history(courserun_key, user, message_count):
     return message_history
 
 
-def get_audit_trial_expiration_date_from_start_date(start_date, user_id, enrollment_mode):
+def get_audit_trial_expiration_date_from_start_date(start_date):
     """
     Given a start date of an audit trial, return the expiration date of the audit trial.
 
@@ -259,8 +258,8 @@ def get_audit_trial_expiration_date_from_start_date(start_date, user_id, enrollm
     Returns:
     * expiration_date (datetime): the expiration date of the audit trial
     """
-    trial_length_days = get_audit_trial_length_days(user_id, enrollment_mode)
-    expiration_datetime = start_date + timedelta(days=trial_length_days)
+    # Default audit trial length is 14 days
+    expiration_datetime = start_date + timedelta(days=AUDIT_TRIAL_MAX_DAYS)
 
     return expiration_datetime
 
@@ -291,7 +290,7 @@ def get_audit_trial(user):
     )
 
 
-def get_or_create_audit_trial(user, enrollment_mode):
+def get_or_create_audit_trial(user):
     """
     Given a user, return the associated audit trial data, creating a new audit trial for the user if one does not exist.
 
@@ -306,7 +305,7 @@ def get_or_create_audit_trial(user, enrollment_mode):
         * expiration_date (datetime): the expiration date of the audit trial
     """
     start_date = timezone.now()
-    expiration_date = get_audit_trial_expiration_date_from_start_date(start_date, user.id, enrollment_mode)
+    expiration_date = get_audit_trial_expiration_date_from_start_date(start_date)
 
     audit_trial, _ = LearningAssistantAuditTrial.objects.get_or_create(
         user=user,

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -156,42 +156,6 @@ def get_optimizely_variation(user_id, enrollment_mode):
     return {'enabled': enabled, 'variation_key': variation_key}
 
 
-def get_audit_trial_length_days(user_id, enrollment_mode):
-    """
-    Return the length of an audit trial in days.
-
-    Arguments:
-    * user_id
-    * enrollment_mode
-
-    Returns:
-    * int: the length of an audit trial in days
-    """
-    variation = get_optimizely_variation(user_id, enrollment_mode)
-
-    # For the sake of the experiment on the backend, the only difference in behavior should be for the 28 day variation.
-    # This is because the control group will never see the audit experience, so the value being returned here does not
-    # matter, and the 14 day variation can use the default trial length of 14 days.
-    if (
-        variation['enabled']
-        and variation['variation_key'] == getattr(settings, 'OPTIMIZELY_LEARNING_ASSISTANT_TRIAL_VARIATION_KEY_28', '')
-    ):
-        trial_length_days = 28
-    else:
-        default_trial_length_days = 14
-        trial_length_days = getattr(settings, 'LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS', default_trial_length_days)
-
-    if trial_length_days is None:
-        trial_length_days = default_trial_length_days
-
-    # If LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS is set to a negative number, assume it should be 0.
-    # pylint: disable=consider-using-max-builtin
-    if trial_length_days < 0:
-        trial_length_days = 0
-
-    return trial_length_days
-
-
 def parse_lms_datetime(datetime_string):
     """
     Parse an LMS datetime into a timezone-aware, Python datetime object.

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -33,17 +33,12 @@ from learning_assistant.api import (
     render_prompt_template,
     save_chat_message,
 )
+from learning_assistant.constants import AUDIT_TRIAL_MAX_DAYS
 from learning_assistant.models import LearningAssistantMessage
 from learning_assistant.platform_imports import get_cache_course_run_data
 from learning_assistant.serializers import MessageSerializer
 from learning_assistant.toggles import chat_history_enabled
-from learning_assistant.utils import (
-    extract_message_content,
-    get_audit_trial_length_days,
-    get_chat_response,
-    parse_lms_datetime,
-    user_role_is_staff,
-)
+from learning_assistant.utils import extract_message_content, get_chat_response, parse_lms_datetime, user_role_is_staff
 
 log = logging.getLogger(__name__)
 
@@ -178,7 +173,7 @@ class CourseChatView(APIView):
         # If user has an audit enrollment record, get or create their trial. If the trial is not expired, return the
         # next message. Otherwise, return 403
         elif enrollment_mode in CourseMode.UPSELL_TO_VERIFIED_MODES:  # AUDIT, HONOR
-            audit_trial = get_or_create_audit_trial(request.user, enrollment_mode)
+            audit_trial = get_or_create_audit_trial(request.user)
             is_user_audit_trial_expired = audit_trial_is_expired(enrollment_object, audit_trial)
             if is_user_audit_trial_expired:
                 return Response(
@@ -335,6 +330,7 @@ class LearningAssistantChatSummaryView(APIView):
 
         data['audit_trial'] = trial_data
 
-        data['audit_trial_length_days'] = get_audit_trial_length_days(user.id, enrollment_mode)
+        # Default audit trial length is 14 days
+        data['audit_trial_length_days'] = AUDIT_TRIAL_MAX_DAYS
 
         return Response(status=http_status.HTTP_200_OK, data=data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -532,23 +532,15 @@ class GetAuditTrialExpirationDateFromStartTests(TestCase):
     """
 
     @ddt.data(
-        (datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 2, 0, 0, 0), 1),
-        (datetime(2024, 1, 18, 0, 0, 0), datetime(2024, 1, 19, 0, 0, 0), 1),
-        (datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 8, 0, 0, 0), 7),
-        (datetime(2024, 1, 18, 0, 0, 0), datetime(2024, 1, 25, 0, 0, 0), 7),
-        (datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 15, 0, 0, 0), 14),
-        (datetime(2024, 1, 18, 0, 0, 0), datetime(2024, 2, 1, 0, 0, 0), 14),
+        (datetime(2024, 1, 1, 0, 0, 0), datetime(2024, 1, 15, 0, 0, 0)),
+        (datetime(2024, 1, 18, 0, 0, 0), datetime(2024, 2, 1, 0, 0, 0)),
     )
     @ddt.unpack
-    @patch('learning_assistant.api.get_audit_trial_length_days')
     def test_expiration_date(
         self, start_date,
         expected_expiration_date,
-        trial_length_days,
-        mock_get_audit_trial_length_days
     ):
-        mock_get_audit_trial_length_days.return_value = trial_length_days
-        expiration_date = get_audit_trial_expiration_date_from_start_date(start_date, 1, 'verified')
+        expiration_date = get_audit_trial_expiration_date_from_start_date(start_date)
         self.assertEqual(expected_expiration_date, expiration_date)
 
 
@@ -623,7 +615,7 @@ class GetOrCreateAuditTrialTests(TestCase):
             start_date=audit_trial_start_date,
             expiration_date=timezone.make_aware(audit_trial_expiration_date),
         )
-        self.assertEqual(expected_return, get_or_create_audit_trial(self.user, 'verified'))
+        self.assertEqual(expected_return, get_or_create_audit_trial(self.user))
 
     @freeze_time('2024-01-01')
     @ddt.data(
@@ -644,7 +636,7 @@ class GetOrCreateAuditTrialTests(TestCase):
             expiration_date=timezone.make_aware(audit_trial_expiration_date)
         )
 
-        self.assertEqual(expected_return, get_or_create_audit_trial(self.user, 'verified'))
+        self.assertEqual(expected_return, get_or_create_audit_trial(self.user))
 
 
 @ddt.ddt
@@ -715,7 +707,7 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
         audit_trial_data = LearningAssistantAuditTrialData(
             user_id=self.user.id,
             start_date=start_date,
-            expiration_date=get_audit_trial_expiration_date_from_start_date(start_date, 1, 'verified'),
+            expiration_date=get_audit_trial_expiration_date_from_start_date(start_date),
         )
 
         self.assertEqual(audit_trial_is_expired(mock_enrollment, audit_trial_data), True)
@@ -729,7 +721,7 @@ class CheckIfAuditTrialIsExpiredTests(TestCase):
         audit_trial_data = LearningAssistantAuditTrialData(
             user_id=self.user.id,
             start_date=start_date,
-            expiration_date=get_audit_trial_expiration_date_from_start_date(start_date, 1, 'verified'),
+            expiration_date=get_audit_trial_expiration_date_from_start_date(start_date),
         )
 
         self.assertEqual(audit_trial_is_expired(mock_enrollment, audit_trial_data), False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,6 @@ from requests.exceptions import ConnectTimeout
 from learning_assistant.constants import LMS_DATETIME_FORMAT
 from learning_assistant.utils import (
     extract_message_content,
-    get_audit_trial_length_days,
     get_chat_response,
     get_optimizely_variation,
     get_reduced_message_list,
@@ -219,44 +218,6 @@ class UserRoleIsStaffTests(TestCase):
     @ddt.unpack
     def test_user_role_is_staff(self, role, expected_value):
         self.assertEqual(user_role_is_staff(role), expected_value)
-
-
-@ddt.ddt
-class GetAuditTrialLengthDaysTests(TestCase):
-    """
-    Tests for the get_audit_trial_length_days helper function.
-    """
-    @ddt.data(
-        (None, 14),
-        (0, 0),
-        (-7, 0),
-        (7, 7),
-        (14, 14),
-        (28, 28),
-    )
-    @ddt.unpack
-    def test_get_audit_trial_length_days_with_value(self, setting_value, expected_value):
-        with patch.object(settings, 'LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS', setting_value):
-            self.assertEqual(get_audit_trial_length_days(1, 'verified'), expected_value)
-
-    @override_settings()
-    def test_get_audit_trial_length_days_no_setting(self):
-        del settings.LEARNING_ASSISTANT_AUDIT_TRIAL_LENGTH_DAYS
-        self.assertEqual(get_audit_trial_length_days(1, 'verified'), 14)
-
-    # mock optimizely function
-    @ddt.data(
-        ('variation', 28),
-        ('control', 14),
-    )
-    @ddt.unpack
-    @patch('learning_assistant.utils.get_optimizely_variation')
-    def test_get_audit_trial_length_days_experiment(
-        self, variation_key, expected_value, mock_get_optimizely_variation
-    ):
-        mock_get_optimizely_variation.return_value = {'enabled': True, 'variation_key': variation_key}
-        with patch.object(settings, 'OPTIMIZELY_LEARNING_ASSISTANT_TRIAL_VARIATION_KEY_28', 'variation'):
-            self.assertEqual(get_audit_trial_length_days(1, 'verified'), expected_value)
 
 
 class GetOptimizelyVariationTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -21,6 +21,7 @@ from freezegun import freeze_time
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
+from learning_assistant.constants import AUDIT_TRIAL_MAX_DAYS
 from learning_assistant.models import LearningAssistantAuditTrial, LearningAssistantMessage
 
 User = get_user_model()
@@ -552,14 +553,12 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             ['verified', 'credit', 'no-id', 'audit', None],  # course mode
             [True, False],                                   # trial available
             [True, False],                                   # trial expired
-            [7, 14],                                         # trial length
         )
     )
     @ddt.unpack
     @patch('learning_assistant.views.audit_trial_is_expired')
     @patch('learning_assistant.views.chat_history_enabled')
     @patch('learning_assistant.views.learning_assistant_enabled')
-    @patch('learning_assistant.views.get_audit_trial_length_days')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment')
     @patch('learning_assistant.views.CourseMode')
@@ -571,11 +570,10 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
         course_mode_mock_value,
         trial_available,
         audit_trial_is_expired_mock_value,
-        audit_trial_length_days_mock_value,
+
         mock_mode,
         mock_enrollment,
         mock_get_user_role,
-        mock_get_audit_trial_length_days,
         mock_learning_assistant_enabled,
         mock_chat_history_enabled,
         mock_audit_trial_is_expired,
@@ -616,10 +614,9 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
 
         # Set up audit trial data.
         mock_audit_trial_is_expired.return_value = audit_trial_is_expired_mock_value
-        mock_get_audit_trial_length_days.return_value = audit_trial_length_days_mock_value
 
         audit_trial_start_date = timezone.now()
-        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=audit_trial_length_days_mock_value)
+        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=AUDIT_TRIAL_MAX_DAYS)
         if trial_available:
             LearningAssistantAuditTrial.objects.create(
                 user=self.user,
@@ -671,7 +668,7 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             expected_trial_data['expiration_date'] = audit_trial_expiration_date
 
         self.assertEqual(response.data['audit_trial'], expected_trial_data)
-        self.assertEqual(response.data['audit_trial_length_days'], audit_trial_length_days_mock_value)
+        self.assertEqual(response.data['audit_trial_length_days'], AUDIT_TRIAL_MAX_DAYS)
 
     @freeze_time('2024-01-01')
     @ddt.data(
@@ -682,14 +679,12 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             ['verified', 'credit', 'no-id'],  # course mode
             [True, False],                    # trial available
             [True, False],                    # trial expired
-            [7, 14],                          # trial length
         )
     )
     @ddt.unpack
     @patch('learning_assistant.views.audit_trial_is_expired')
     @patch('learning_assistant.views.chat_history_enabled')
     @patch('learning_assistant.views.learning_assistant_enabled')
-    @patch('learning_assistant.views.get_audit_trial_length_days')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment')
     @patch('learning_assistant.views.CourseMode')
@@ -701,11 +696,9 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
         course_mode_mock_value,
         trial_available,
         audit_trial_is_expired_mock_value,
-        audit_trial_length_days_mock_value,
         mock_mode,
         mock_enrollment,
         mock_get_user_role,
-        mock_get_audit_trial_length_days,
         mock_learning_assistant_enabled,
         mock_chat_history_enabled,
         mock_audit_trial_is_expired,
@@ -746,10 +739,9 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
 
         # Set up audit trial data.
         mock_audit_trial_is_expired.return_value = audit_trial_is_expired_mock_value
-        mock_get_audit_trial_length_days.return_value = audit_trial_length_days_mock_value
 
         audit_trial_start_date = timezone.now()
-        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=audit_trial_length_days_mock_value)
+        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=AUDIT_TRIAL_MAX_DAYS)
         if trial_available:
             LearningAssistantAuditTrial.objects.create(
                 user=self.user,
@@ -801,7 +793,7 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             expected_trial_data['expiration_date'] = audit_trial_expiration_date
 
         self.assertEqual(response.data['audit_trial'], expected_trial_data)
-        self.assertEqual(response.data['audit_trial_length_days'], audit_trial_length_days_mock_value)
+        self.assertEqual(response.data['audit_trial_length_days'], AUDIT_TRIAL_MAX_DAYS)
 
     @freeze_time('2024-01-01')
     @ddt.data(
@@ -812,14 +804,12 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             ['audit'],      # course mode
             [True, False],  # trial available
             [True, False],  # trial expired
-            [7, 14],        # trial length
         )
     )
     @ddt.unpack
     @patch('learning_assistant.views.audit_trial_is_expired')
     @patch('learning_assistant.views.chat_history_enabled')
     @patch('learning_assistant.views.learning_assistant_enabled')
-    @patch('learning_assistant.views.get_audit_trial_length_days')
     @patch('learning_assistant.views.get_user_role')
     @patch('learning_assistant.views.CourseEnrollment')
     @patch('learning_assistant.views.CourseMode')
@@ -831,11 +821,9 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
         course_mode_mock_value,
         trial_available,
         audit_trial_is_expired_mock_value,
-        audit_trial_length_days_mock_value,
         mock_mode,
         mock_enrollment,
         mock_get_user_role,
-        mock_get_audit_trial_length_days,
         mock_learning_assistant_enabled,
         mock_chat_history_enabled,
         mock_audit_trial_is_expired,
@@ -876,10 +864,9 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
 
         # Set up audit trial data.
         mock_audit_trial_is_expired.return_value = audit_trial_is_expired_mock_value
-        mock_get_audit_trial_length_days.return_value = audit_trial_length_days_mock_value
 
         audit_trial_start_date = timezone.now()
-        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=audit_trial_length_days_mock_value)
+        audit_trial_expiration_date = audit_trial_start_date + timedelta(days=AUDIT_TRIAL_MAX_DAYS)
         if trial_available:
             LearningAssistantAuditTrial.objects.create(
                 user=self.user,
@@ -931,7 +918,7 @@ class LearningAssistantChatSummaryViewTests(LoggedInTestCase):
             expected_trial_data['expiration_date'] = audit_trial_expiration_date
 
         self.assertEqual(response.data['audit_trial'], expected_trial_data)
-        self.assertEqual(response.data['audit_trial_length_days'], audit_trial_length_days_mock_value)
+        self.assertEqual(response.data['audit_trial_length_days'], AUDIT_TRIAL_MAX_DAYS)
 
     @ddt.data({
         'start': '2023-01-01T01:00:00Z',  # past date


### PR DESCRIPTION
Replaced logic for determining different audit trial lengths, as we are rolling out a 14 day trial.

Ticket for context: https://2u-internal.atlassian.net/jira/software/c/projects/COSMO2/boards/2821?selectedIssue=COSMO2-103
