### PR TITLE
large system message in XpertAssistant

### DIFF
--- a/learning_assistant/api.py
+++ b/learning_assistant/api.py
@@ -133,7 +133,34 @@ def render_prompt_template(request, user_id, course_run_id, unit_usage_key, cour
     # buffer. This limit also prevents an error from occurring wherein unusually long prompt templates cause an
     # error due to using too many tokens.
     UNIT_CONTENT_MAX_CHAR_LENGTH = getattr(settings, 'CHAT_COMPLETION_UNIT_CONTENT_MAX_CHAR_LENGTH', 11750)
-    unit_content = unit_content[0:UNIT_CONTENT_MAX_CHAR_LENGTH]
+
+    # --- Proportional trimming logic ---
+    if isinstance(unit_content, list):
+        # Create a new list of dictionaries to hold trimmed content
+        trimmed_unit_content = []
+
+        total_chars = sum(len(str(item.get("content_text", "")).strip()) for item in unit_content) or 1
+        current_length = 0
+
+        for item in unit_content:
+            ctype = item.get("content_type", "")
+            text = str(item.get("content_text", "")).strip()
+
+            if not text:
+                trimmed_unit_content.append({"content_type": ctype, "content_text": ""})
+                continue
+
+            allowed_chars = max(1, int((len(text) / total_chars) * UNIT_CONTENT_MAX_CHAR_LENGTH))
+            trimmed_text = text[:allowed_chars]
+            trimmed_unit_content.append({"content_type": ctype, "content_text": trimmed_text})
+            current_length += len(trimmed_text)
+
+        # Keep the trimmed content as a list of dictionaries
+        unit_content = trimmed_unit_content
+
+    else:
+        # For non-list content, keep as string trimmed
+        unit_content = unit_content[0:UNIT_CONTENT_MAX_CHAR_LENGTH]
 
     course_data = get_cache_course_data(course_id, ['skill_names', 'title'])
     skill_names = course_data['skill_names']


### PR DESCRIPTION
This PR addresses a bug where excessively large system messages, typically caused by unit content with extensive video transcripts, result in Xpert message failures. In these scenarios, the system prompt consumes the entire token limit, leaving no room for learner or LA messages, thus breaking the interaction flow.

BRANCH: cosmos2-14/naincy128

Resolution:

Unit content is now handled using proportional trimming before sending to Xpert.
This ensures the prompt includes a balanced amount of all content types, leaving enough room for both learner and LA messages.
Test Coverage:

Confirmed that learner messages now reach Xpert successfully.
Added unit tests to validate trimming behaviour for extremely large unit contents.
All tests and lint checks pass.

Jira ticket: https://2u-internal.atlassian.net/browse/COSMO2-14