### PR TITLE
feat: include new params in llm api call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Change Log
 
 Unreleased
 **********
+4.11.4 - 2026-04-17
+*******************
+* To include additional, optional parameters so that learning assistant messages are included in downstream reports and analysis.
+
+  * Specific changes to the API call:
+
+    added Conversation-History-ID header item
+    added external_id body property, only to v2 version of api call
 
 4.11.3 - 2025-10-08
 *******************

--- a/learning_assistant/__init__.py
+++ b/learning_assistant/__init__.py
@@ -2,6 +2,6 @@
 Plugin for a learning assistant backend, intended for use within edx-platform.
 """
 
-__version__ = '4.11.3'
+__version__ = '4.11.4'
 
 default_app_config = 'learning_assistant.apps.LearningAssistantConfig'  # pylint: disable=invalid-name

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -80,11 +80,11 @@ def create_request_body(prompt_template, message_list, user_id):
 
 def create_conversation_history_id(user_id, course_run_id):
     """
-    Create a conversation history id for a given user and course.
+    Create a conversation history id for a given user and course run.
 
     Arguments:
     * user_id: the user's id
-    * course_id: the course's id
+    * course_run_id: the course run's id
 
     Returns:
     * str: the conversation history id

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -113,7 +113,7 @@ def get_chat_response(prompt_template, message_list, user_id, course_run_id):
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
         body = create_request_body(prompt_template, message_list, user_id)
-        log.debug('Sending request to chat completion API with user id: %s', user_id)
+
         try:
             response = requests.post(
                 completion_endpoint,

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -72,7 +72,7 @@ def create_request_body(prompt_template, message_list, user_id):
             'client_id': getattr(settings, 'CHAT_COMPLETION_CLIENT_ID', 'edx_olc_la'),
             'system_message': prompt_template,
             'messages': messages,
-            'external_id': user_id,
+            'external_id': str(user_id),
         }
 
     return response_body
@@ -113,7 +113,7 @@ def get_chat_response(prompt_template, message_list, user_id, course_run_id):
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
         body = create_request_body(prompt_template, message_list, user_id)
-
+        log.debug('Sending request to chat completion API with user id: %s', user_id)
         try:
             response = requests.post(
                 completion_endpoint,

--- a/learning_assistant/utils.py
+++ b/learning_assistant/utils.py
@@ -4,6 +4,7 @@ Utils file for learning-assistant.
 import copy
 import json
 import logging
+import uuid
 from datetime import datetime
 
 import requests
@@ -56,7 +57,7 @@ def get_reduced_message_list(prompt_template, message_list):
     return new_message_list
 
 
-def create_request_body(prompt_template, message_list):
+def create_request_body(prompt_template, message_list, user_id):
     """
     Form request body to be passed to the chat endpoint.
     """
@@ -71,23 +72,47 @@ def create_request_body(prompt_template, message_list):
             'client_id': getattr(settings, 'CHAT_COMPLETION_CLIENT_ID', 'edx_olc_la'),
             'system_message': prompt_template,
             'messages': messages,
+            'external_id': user_id,
         }
 
     return response_body
 
 
-def get_chat_response(prompt_template, message_list):
+def create_conversation_history_id(user_id, course_run_id):
+    """
+    Create a conversation history id for a given user and course.
+
+    Arguments:
+    * user_id: the user's id
+    * course_id: the course's id
+
+    Returns:
+    * str: the conversation history id
+    """
+    convo_hist_seed = f'{user_id}_{course_run_id}'
+
+    # Use a pre-defined namespace (e.g., DNS, URL, OID, or X500)
+    namespace = uuid.NAMESPACE_URL
+
+    # Generate the same UUID every time for the same string
+    deterministic_uuid = uuid.uuid5(namespace, convo_hist_seed)
+
+    return str(deterministic_uuid)
+
+
+def get_chat_response(prompt_template, message_list, user_id, course_run_id):
     """
     Pass message list to chat endpoint, as defined by the CHAT_COMPLETION_API setting.
     """
     completion_endpoint = getattr(settings, 'CHAT_COMPLETION_API_V2', None) if v2_endpoint_enabled() \
         else getattr(settings, 'CHAT_COMPLETION_API', None)
     if completion_endpoint:
-        headers = {'Content-Type': 'application/json'}
+        conversation_history_id = create_conversation_history_id(user_id, course_run_id)
+        headers = {'Content-Type': 'application/json', 'Conversation-History-ID': conversation_history_id}
         connect_timeout = getattr(settings, 'CHAT_COMPLETION_API_CONNECT_TIMEOUT', 1)
         read_timeout = getattr(settings, 'CHAT_COMPLETION_API_READ_TIMEOUT', 15)
 
-        body = create_request_body(prompt_template, message_list)
+        body = create_request_body(prompt_template, message_list, user_id)
 
         try:
             response = requests.post(

--- a/learning_assistant/views.py
+++ b/learning_assistant/views.py
@@ -108,7 +108,7 @@ class CourseChatView(APIView):
         prompt_template = render_prompt_template(
             request, request.user.id, course_run_id, unit_id, course_id, template_string
         )
-        status_code, message = get_chat_response(prompt_template, message_list)
+        status_code, message = get_chat_response(prompt_template, message_list, request.user.id, course_run_id)
 
         if chat_history_enabled(courserun_key):
             content = extract_message_content(message)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 Tests for the utils functions
 """
 import json
+import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -33,10 +34,11 @@ class GetChatResponseTests(TestCase):
         self.prompt_template = 'This is a prompt.'
 
         self.message_list = [{'role': 'assistant', 'content': 'Hello'}, {'role': 'user', 'content': 'Goodbye'}]
+        self.user_id = "testing@tempuri.false"
         self.course_id = 'edx+test'
 
     def get_response(self):
-        return get_chat_response(self.prompt_template, self.message_list)
+        return get_chat_response(self.prompt_template, self.message_list, self.user_id, self.course_id)
 
     @override_settings(CHAT_COMPLETION_API=None)
     def test_no_endpoint_setting(self):
@@ -106,10 +108,12 @@ class GetChatResponseTests(TestCase):
     def test_post_request_structure(self, mock_requests):
         mock_requests.post = MagicMock()
 
+        mock_convo_hist_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f'{self.user_id}_{self.course_id}'))
+
         completion_endpoint = settings.CHAT_COMPLETION_API
         connect_timeout = settings.CHAT_COMPLETION_API_CONNECT_TIMEOUT
         read_timeout = settings.CHAT_COMPLETION_API_READ_TIMEOUT
-        headers = {'Content-Type': 'application/json'}
+        headers = {'Content-Type': 'application/json', 'Conversation-History-ID': mock_convo_hist_id}
 
         response_body = {
             'message_list': [{'role': 'system', 'content': self.prompt_template}] + self.message_list,
@@ -129,15 +133,18 @@ class GetChatResponseTests(TestCase):
         mock_requests.post = MagicMock()
         mock_v2_enabled.return_value = True
 
+        mock_convo_hist_id = str(uuid.uuid5(uuid.NAMESPACE_URL, f'{self.user_id}_{self.course_id}'))
+
         completion_endpoint_v2 = settings.CHAT_COMPLETION_API_V2
         connect_timeout = settings.CHAT_COMPLETION_API_CONNECT_TIMEOUT
         read_timeout = settings.CHAT_COMPLETION_API_READ_TIMEOUT
-        headers = {'Content-Type': 'application/json'}
+        headers = {'Content-Type': 'application/json', 'Conversation-History-ID': mock_convo_hist_id}
 
         response_body = {
             'client_id': 'edx_olc_la',
             'system_message': self.prompt_template,
             'messages': self.message_list,
+            'external_id': self.user_id,
         }
 
         self.get_response()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -340,6 +340,8 @@ class CourseChatViewTests(LoggedInTestCase):
         mock_chat_response.assert_called_with(
             'Rendered template mock',
             test_data,
+            self.user.id,
+            self.course_id,
         )
 
         if enabled_flag:


### PR DESCRIPTION
Updated call to llm backend to include additional, optional parameters so that learning assistant messages are included in downstream reports and analysis.

Specific changes to the API call:
* added `Conversation-History-ID` header item
* added `external_id` body property, only to `v2` version of api call


